### PR TITLE
feature: added custom fps video capture setting

### DIFF
--- a/app/src/main/java/com/fadcam/Constantes.java
+++ b/app/src/main/java/com/fadcam/Constantes.java
@@ -1,0 +1,8 @@
+package com.fadcam;
+
+public abstract class Constantes {
+    public static final String PREF_VIDEO_QUALITY = "video_quality";
+    public static final String PREF_VIDEO_FRAMERATE = "video_framerate";
+
+    public static final int DEFAULT_VIDEO_FRAMERATE = 30;
+}

--- a/app/src/main/java/com/fadcam/ui/HomeFragment.java
+++ b/app/src/main/java/com/fadcam/ui/HomeFragment.java
@@ -1,9 +1,6 @@
 package com.fadcam.ui;
 
 
-import static androidx.core.content.ContextCompat.getSystemService;
-
-
 import android.Manifest;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
@@ -30,12 +27,14 @@ import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.StatFs;
+import android.os.SystemClock;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.text.Html;
 import android.text.Spanned;
 import android.text.format.Formatter;
 import android.util.Log;
+import android.util.Range;
 import android.view.LayoutInflater;
 import android.view.Surface;
 import android.view.TextureView;
@@ -52,9 +51,10 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
-import com.arthenica.ffmpegkit.FFmpegKit;
 import com.arthenica.ffmpegkit.ExecuteCallback;
+import com.arthenica.ffmpegkit.FFmpegKit;
 import com.arthenica.ffmpegkit.Session;
+import com.fadcam.Constantes;
 import com.fadcam.R;
 import com.fadcam.RecordingService;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -65,20 +65,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.SimpleDateFormat;
+import java.time.chrono.HijrahChronology;
+import java.time.chrono.HijrahDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Locale;
-
-import android.os.SystemClock;
-
-import java.time.format.DateTimeFormatter;
-import java.time.chrono.HijrahChronology;
-import java.time.chrono.HijrahDate;
-
 import java.util.List;
-import java.util.Objects;
+import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -121,7 +116,6 @@ public class HomeFragment extends Fragment {
     private boolean isTypingIn = true;
     private String currentTip = "";
 
-    private static final String PREF_VIDEO_QUALITY = "video_quality";
     private static final String QUALITY_SD = "SD";
     private static final String QUALITY_HD = "HD";
     private static final String QUALITY_FHD = "FHD";
@@ -472,7 +466,7 @@ public class HomeFragment extends Fragment {
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        tips = Objects.requireNonNull(getActivity()).getResources().getStringArray(R.array.tips_widget);
+        tips = requireActivity().getResources().getStringArray(R.array.tips_widget);
         super.onViewCreated(view, savedInstanceState);
         Log.d(TAG, "onViewCreated: Setting up UI components");
 
@@ -992,7 +986,7 @@ public class HomeFragment extends Fragment {
 //    }
 
     private void setVideoBitrate() {
-        String selectedQuality = sharedPreferences.getString(PREF_VIDEO_QUALITY, QUALITY_HD);
+        String selectedQuality = sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
         switch (selectedQuality) {
             case QUALITY_SD:
                 videoBitrate = 1000000; // 1 Mbps
@@ -1086,6 +1080,12 @@ public class HomeFragment extends Fragment {
             }
             captureRequestBuilder.addTarget(recorderSurface);
 
+            int selectedFramerate = sharedPreferences.getInt(Constantes.PREF_VIDEO_FRAMERATE, Constantes.DEFAULT_VIDEO_FRAMERATE);
+
+            // Define framerate
+            Range<Integer> fpsRange = Range.create(selectedFramerate, selectedFramerate);
+            captureRequestBuilder.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, fpsRange);
+
             cameraDevice.createCaptureSession(Arrays.asList(previewSurface, recorderSurface),
                     new CameraCaptureSession.StateCallback() {
                         @Override
@@ -1134,29 +1134,29 @@ public class HomeFragment extends Fragment {
             mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
             mediaRecorder.setOutputFile(videoFile.getAbsolutePath());
 
-            String selectedQuality = sharedPreferences.getString(PREF_VIDEO_QUALITY, QUALITY_HD);
+            String selectedQuality = sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
             switch (selectedQuality) {
                 case QUALITY_SD:
                     mediaRecorder.setVideoSize(640, 480);
                     mediaRecorder.setVideoEncodingBitRate(1000000); // 1 Mbps
-                    mediaRecorder.setVideoFrameRate(30);
                     break;
                 case QUALITY_HD:
                     mediaRecorder.setVideoSize(1280, 720);
                     mediaRecorder.setVideoEncodingBitRate(5000000); // 5 Mbps
-                    mediaRecorder.setVideoFrameRate(30);
                     break;
                 case QUALITY_FHD:
                     mediaRecorder.setVideoSize(1920, 1080);
                     mediaRecorder.setVideoEncodingBitRate(10000000); // 10 Mbps
-                    mediaRecorder.setVideoFrameRate(30);
                     break;
                 default:
                     mediaRecorder.setVideoSize(1280, 720);
                     mediaRecorder.setVideoEncodingBitRate(5000000); // 5 Mbps
-                    mediaRecorder.setVideoFrameRate(30);
                     break;
             }
+
+            int selectedFramerate = sharedPreferences.getInt(Constantes.PREF_VIDEO_FRAMERATE, Constantes.DEFAULT_VIDEO_FRAMERATE);
+            mediaRecorder.setVideoFrameRate(selectedFramerate);
+            mediaRecorder.setCaptureRate(selectedFramerate);
 
             mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
             mediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.H264);
@@ -1427,7 +1427,7 @@ public class HomeFragment extends Fragment {
     }
 
     private int getVideoBitrate() {
-        String selectedQuality = sharedPreferences.getString(PREF_VIDEO_QUALITY, QUALITY_HD);
+        String selectedQuality = sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
         int bitrate;
         switch (selectedQuality) {
             case QUALITY_SD:

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -229,6 +229,55 @@
 
             </LinearLayout>
 
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?android:attr/listDivider"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_vid_cam"
+                    android:layout_marginEnd="8dp"/>
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="4dp"
+                        android:text="@string/setting_framerate_title"
+                        android:textAppearance="?attr/textAppearanceSubtitle1"
+                        android:textColor="@color/colorPrimary" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/framerate_note_textview"
+                        android:textAppearance="?attr/textAppearanceCaption"
+                        android:textColor="?android:attr/textColorSecondary" />
+
+                </LinearLayout>
+
+                <Spinner
+                    android:id="@+id/framerate_spinner"
+                    android:layout_width="wrap_content"
+                    android:layout_height="48dp"/>
+
+            </LinearLayout>
+
             <!-- Add divider for new section -->
             <View
                 android:layout_width="match_parent"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -80,7 +80,9 @@
     <string name="button_settings_cam_back">Arrière</string>
     <string name="button_settings_cam_front">Frontale</string>
     <string name="setting_quailty_title">Qualité vidéo</string>
+    <string name="setting_framerate_title">Fréquence vidéo</string>
     <string name="note_quailty">Choix de la qualité\n(Défaut: HD)</string>
+    <string name="note_framerate">Choix de la fréquence\n(Défaut: %1$d)</string>
     <string name="setting_watermark">Filigrane</string>
     <string name="note_watermark">Sélectionner l\'option filigrane\n(Défaut: Horodatage avec Fadcam)</string>
     <string name="note_watermark_extra">Pour une sauvegarde rapide, choisissez \'Aucun\'. Ajouter un filigrane ? Ça vaut la peine d\'attendre, juste un peu plus pour traiter !</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -6,6 +6,13 @@
         <item>@item/quality_sd</item>
     </string-array>
 
+    <integer-array name="video_framerate_options">
+        <item>24</item>
+        <item>30</item>
+        <item>60</item>
+        <item>90</item>
+    </integer-array>
+
     <string-array name="languages_array">
         <item>English (English) 🇬🇧</item> <!-- British flag -->
         <item>Chinese (中文) 🇨🇳</item> <!-- Chinese flag -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,12 @@
         <item name="quality_hd">HD (1280x720)</item>
         <item name="quality_sd">SD (640x480)</item>
     </string-array>
+    <string-array name="video_framerate_array">
+        <item name="24">24</item>
+        <item name="30">30</item>
+        <item name="60">60</item>
+        <item name="90">90</item>
+    </string-array>
     <string name="mainpage_storage_indicator">\n    <![CDATA[
     <font color=\'#FFFFFF\' style=\'font-size:16sp;\'><b>Available:</b></font><br>
     <font color=\'#CCCCCC\' style=\'font-size:14sp;\'>%.2f GB / %.2f GB</font><br><br>
@@ -82,7 +88,9 @@
     <string name="button_settings_cam_back">Back</string>
     <string name="button_settings_cam_front">Front</string>
     <string name="setting_quailty_title">Video Quality</string>
+    <string name="setting_framerate_title">Video Framerate</string>
     <string name="note_quailty">Choose quality\n(Default: HD)</string>
+    <string name="note_framerate">Choose framerate\n(Default: %1$d)</string>
     <string name="setting_watermark">Watermark</string>
     <string name="note_watermark">Select watermark option\n(Default: Timestamp with FadCam)</string>
     <string name="note_watermark_extra">For a speedy save, pick \'No Watermark\'. Adding a watermark? It’s worth the wait, just a little longer to process!</string>


### PR DESCRIPTION
I used the CaptureRequest.Builder object and also MediaRecorder.
MediaRecorder is apparently not compatible with all devices and CaptureRequest too, so as a precaution I used both ways for greater devices coverage.

I put four options : 24, 30, 60 and 90 (maybe 24 fps is not necessary ?)

I couldn't test the video capture at 60 and 90 fps because I don't have the necessary hardware but 24 and 30 fps modes work well.
See if mode 60 and 90 fps changes file size (which does not seem to be the case with 24 and 30 fps modes). Otherwise the storage space information widget will also need to be updated.

![Screenshot_20240916_210441](https://github.com/user-attachments/assets/1890941a-c1fa-4426-9a2a-432ddeb9a0d7)

I have also grouped constants used in several files into the same Constants file to avoid duplication.

#23 