### PR TITLE
Bad audio quality and missing notifications permission fixed, max camera frame rates refactoring

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
 
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 
 

--- a/app/src/main/java/com/fadcam/Constantes.java
+++ b/app/src/main/java/com/fadcam/Constantes.java
@@ -8,14 +8,6 @@ public abstract class Constantes {
     public static final String PREF_VIDEO_FRAMERATE = "video_framerate";
     public static final String PREF_CAMERA_SELECTION = "camera_selection";
 
-    public static int CAMERA_FRONT_FHD_MAX_FRAMERATES = 0;
-    public static int CAMERA_FRONT_HD_MAX_FRAMERATES = 0;
-    public static int CAMERA_FRONT_SD_MAX_FRAMERATES = 0;
-
-    public static int CAMERA_BACK_FHD_MAX_FRAMERATES = 0;
-    public static int CAMERA_BACK_HD_MAX_FRAMERATES = 0;
-    public static int CAMERA_BACK_SD_MAX_FRAMERATES = 0;
-
     public static final String CAMERA_FRONT = "front";
     public static final String CAMERA_BACK = "back";
 }

--- a/app/src/main/java/com/fadcam/ui/HomeFragment.java
+++ b/app/src/main/java/com/fadcam/ui/HomeFragment.java
@@ -20,6 +20,7 @@ import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraDevice;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CaptureRequest;
+import android.media.CamcorderProfile;
 import android.media.MediaRecorder;
 import android.os.Build;
 import android.os.Bundle;
@@ -377,9 +378,10 @@ public class HomeFragment extends Fragment {
             getActivity().registerReceiver(recordingStateReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
         }
 
+        setupStartStopButton();
+
         updateStats();
     }
-
 
     @Override
     public void onPause() {
@@ -1006,6 +1008,10 @@ public class HomeFragment extends Fragment {
         return sharedPreferences.getString(Constantes.PREF_CAMERA_SELECTION, Constantes.CAMERA_BACK);
     }
 
+    private String getCameraQuality() {
+        return sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
+    }
+
     private void closeCamera() {
         if (cameraDevice != null) {
             cameraDevice.close();
@@ -1581,6 +1587,31 @@ public class HomeFragment extends Fragment {
         int read;
         while ((read = in.read(buffer)) != -1) {
             out.write(buffer, 0, read);
+        }
+    }
+
+    private void setupStartStopButton()
+    {
+        if (!CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_1080P) && getCameraSelection().equals(Constantes.CAMERA_FRONT) && getCameraQuality().equals(QUALITY_FHD)) {
+            buttonStartStop.setEnabled(false);
+        }
+        else if (!CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_720P) && getCameraSelection().equals(Constantes.CAMERA_FRONT) && getCameraQuality().equals(QUALITY_HD)) {
+            buttonStartStop.setEnabled(false);
+        }
+        else if (!CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_VGA) && !CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_480P) && getCameraSelection().equals(Constantes.CAMERA_FRONT) && getCameraQuality().equals(QUALITY_SD)) {
+            buttonStartStop.setEnabled(false);
+        }
+        else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_1080P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_FHD)) {
+            buttonStartStop.setEnabled(false);
+        }
+        else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_720P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_HD)) {
+            buttonStartStop.setEnabled(false);
+        }
+        else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_VGA) && !CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_480P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_SD)) {
+            buttonStartStop.setEnabled(false);
+        }
+        else {
+            buttonStartStop.setEnabled(true);
         }
     }
 

--- a/app/src/main/java/com/fadcam/ui/HomeFragment.java
+++ b/app/src/main/java/com/fadcam/ui/HomeFragment.java
@@ -1155,6 +1155,8 @@ public class HomeFragment extends Fragment {
             mediaRecorder.setVideoFrameRate(selectedFramerate);
             mediaRecorder.setCaptureRate(selectedFramerate);
 
+            mediaRecorder.setAudioEncodingBitRate(384000);
+            mediaRecorder.setAudioSamplingRate(48000);
             mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
             mediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.H264);
 

--- a/app/src/main/java/com/fadcam/ui/HomeFragment.java
+++ b/app/src/main/java/com/fadcam/ui/HomeFragment.java
@@ -161,7 +161,8 @@ public class HomeFragment extends Fragment {
                     Manifest.permission.CAMERA,
                     Manifest.permission.RECORD_AUDIO,
                     Manifest.permission.READ_MEDIA_VIDEO,
-                    Manifest.permission.READ_EXTERNAL_STORAGE
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.POST_NOTIFICATIONS
             };
         } else { // Below Android 11
             permissions = new String[]{


### PR DESCRIPTION
#29 fixed with the highest common audio quality, but as discussed, an option to select audio quality is to be foreseen later
#40 partially fixed (the notification does not appear at the first video capture)
#23 (like #39) need tests for 60 and 90 fps