### PR TITLE
feat: Dual camera recording with front and rear cameras

### DIFF
--- a/app/src/main/java/com/fadcam/Constantes.java
+++ b/app/src/main/java/com/fadcam/Constantes.java
@@ -10,4 +10,5 @@ public abstract class Constantes {
 
     public static final String CAMERA_FRONT = "front";
     public static final String CAMERA_BACK = "back";
+    public static final String CAMERA_DUAL = "dual";
 }

--- a/app/src/main/java/com/fadcam/RecordingService.java
+++ b/app/src/main/java/com/fadcam/RecordingService.java
@@ -52,7 +52,7 @@ public class RecordingService extends Service {
     }
 
     /**
-     * Maneja las acciones de inicio y detención de la grabación.
+     * Handles recording start and stop actions.
      */
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -65,7 +65,7 @@ public class RecordingService extends Service {
                     stopDualRecording();
                     break;
                 default:
-                    Log.w(TAG, "Acción desconocida: " + intent.getAction());
+                    Log.w(TAG, "Unknown action: " + intent.getAction());
             }
         }
         return START_STICKY;
@@ -98,7 +98,7 @@ public class RecordingService extends Service {
     private void setupAndStartRecorders(String cameraSelection) {
         Log.d(TAG, "Setting up recorders for camera: " + cameraSelection);
 
-        // Limpiar los recursos existentes primero
+        // Clear existing resources first
         if (frontRecorder != null) {
             frontRecorder.release();
             frontRecorder = null;
@@ -120,7 +120,7 @@ public class RecordingService extends Service {
                 Log.d(TAG, "Back camera recorder setup completed");
                 break;
             case Constantes.CAMERA_DUAL:
-                // En modo dual, configurar ambos grabadores
+                // In dual mode, set up both recorders
                 frontVideoPath = generateVideoPath(true);
                 backVideoPath = generateVideoPath(false);
                 frontRecorder = setupMediaRecorder(frontVideoPath, true);
@@ -338,7 +338,7 @@ public class RecordingService extends Service {
             stopForeground(true);
             stopSelf();
 
-            // Comunicar al HomeFragment que la grabación ha finalizado
+            // Communicate to HomeFragment that recording has finished
             broadcastRecordingState(false);
 
         } catch (Exception e) {
@@ -368,9 +368,9 @@ public class RecordingService extends Service {
 
     private void startForegroundService() {
         Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
-                .setContentTitle("Grabación Dual")
-                .setContentText("Grabando con ambas cámaras")
-                .setSmallIcon(R.drawable.unknown_icon3) // Asegúrate de tener este ícono en tus recursos
+                .setContentTitle("Dual Recording")
+                .setContentText("Recording with both cameras")
+                .setSmallIcon(R.drawable.unknown_icon3) // Make sure you have this icon in your resources
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .build();
 
@@ -398,9 +398,9 @@ public class RecordingService extends Service {
     }
 
     /**
-     * Envía una transmisión para informar al HomeFragment sobre el estado de grabación.
+     * Broadcasts to inform HomeFragment about the recording state.
      *
-     * @param recordingState true si está grabando, false si no.
+     * @param recordingState true if recording, false if not.
      */
     private void broadcastRecordingState(boolean recordingState) {
         Intent intent = new Intent("RECORDING_STATE_CHANGED");

--- a/app/src/main/java/com/fadcam/RecordingService.java
+++ b/app/src/main/java/com/fadcam/RecordingService.java
@@ -4,8 +4,8 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
-import android.graphics.SurfaceTexture;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraDevice;
@@ -17,42 +17,51 @@ import android.os.IBinder;
 import android.util.Log;
 import android.view.Surface;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 public class RecordingService extends Service {
-
     private static final String CHANNEL_ID = "RecordingServiceChannel";
-    private static final int NOTIFICATION_ID = 1; // Use a constant for the notification ID
-
+    private static final int NOTIFICATION_ID = 1;
     private static final String TAG = "RecordingService";
+
     private boolean isRecording = false;
+    private CameraDevice frontCamera;
+    private CameraDevice backCamera;
+    private MediaRecorder frontRecorder;
+    private MediaRecorder backRecorder;
+    private CameraCaptureSession frontSession;
+    private CameraCaptureSession backSession;
+    private String frontVideoPath;
+    private String backVideoPath;
 
     @Override
     public void onCreate() {
         super.onCreate();
         createNotificationChannel();
-        Log.d(TAG, "Service created");
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        String action = intent.getAction();
-        if (action != null) {
-            switch (action) {
+        if (intent != null && intent.getAction() != null) {
+            switch (intent.getAction()) {
                 case "ACTION_START_RECORDING":
-                    startRecording();
+                    startDualRecording();
                     break;
                 case "ACTION_STOP_RECORDING":
-                    stopRecording();
+                    stopDualRecording();
                     break;
+                default:
+                    Log.w(TAG, "Acción desconocida: " + intent.getAction());
             }
         }
         return START_STICKY;
@@ -64,80 +73,275 @@ public class RecordingService extends Service {
         return null;
     }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        stopRecording();
-        Log.d(TAG, "Service destroyed");
-    }
-
-    private void startRecording() {
-        Log.d(TAG, "startRecording: Initiating video recording from recording service.");
-        if (!isRecording) {
-            isRecording = true;
-            Log.d(TAG, "Recording started from recording service.");
-
-            // Start foreground service
-            Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
-                    .setContentTitle("Recording in progress")
-                    .setContentText("Recording video")
-                    .setSmallIcon(R.drawable.unknown_icon3)
-                    .setPriority(NotificationCompat.PRIORITY_LOW)
-                    .build();
-            startForeground(NOTIFICATION_ID, notification);
-            Log.d(TAG, "Foreground service started");
-
-            Intent intent = new Intent("RECORDING_STATE_CHANGED");
-            intent.putExtra("isRecording", true);
-            sendBroadcast(intent);
-        } else {
-            Log.d(TAG, "Recording already in progress");
-        }
-    }
-
-    private void stopRecording() {
-        Log.d(TAG, "stopRecording: Attempting to stop recording from recording service.");
+    private void startDualRecording() {
         if (isRecording) {
-            isRecording = false;
-            Log.d(TAG, "Recording stopped from recording service");
+            Log.w(TAG, "startDualRecording: Already recording. Ignoring start request.");
+            return;
+        }
+        isRecording = true;
+        startForegroundService();
+        setupAndStartRecorders();
+        openCameras();
 
-            Intent intent = new Intent("RECORDING_STATE_CHANGED");
-            intent.putExtra("isRecording", false);
-            sendBroadcast(intent);
+        broadcastRecordingState(true);
+    }
 
-            stopForeground(STOP_FOREGROUND_REMOVE); // Remove notification
-            Log.d(TAG, "Foreground service stopped, notification should be removed");
+    private void setupAndStartRecorders() {
+        frontVideoPath = generateVideoPath(true);
+        backVideoPath = generateVideoPath(false);
 
-            // Cancel the notification explicitly
-            NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-            if (notificationManager != null) {
-                notificationManager.cancel(NOTIFICATION_ID);
-                Log.d(TAG, "Notification with ID " + NOTIFICATION_ID + " canceled");
+        frontRecorder = setupMediaRecorder(frontVideoPath, true);
+        backRecorder = setupMediaRecorder(backVideoPath, false);
+    }
+
+    private MediaRecorder setupMediaRecorder(String outputPath, boolean isFrontCamera) {
+        MediaRecorder recorder = new MediaRecorder();
+        try {
+            recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+            recorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
+            recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
+            recorder.setVideoEncoder(MediaRecorder.VideoEncoder.H264);
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
+            recorder.setVideoEncodingBitRate(8000000);
+            recorder.setVideoFrameRate(30);
+            recorder.setVideoSize(1920, 1080);
+            recorder.setOutputFile(outputPath);
+
+            if (isFrontCamera) {
+                recorder.setOrientationHint(270);
             } else {
-                Log.e(TAG, "NotificationManager is null, unable to cancel notification");
+                recorder.setOrientationHint(90);
             }
 
-            stopSelf();  // Stop the service
-            Log.d(TAG, "Service stopped");
-        } else {
-            Log.d(TAG, "No recording to stop from recording service");
+            recorder.prepare();
+            return recorder;
+        } catch (IOException e) {
+            Log.e(TAG, "Error preparing MediaRecorder: " + e.getMessage());
+            return null;
         }
+    }
+
+    private String generateVideoPath(boolean isFrontCamera) {
+        String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(new Date());
+        File mediaDir = new File(getExternalFilesDir(null), "FadCam");
+        if (!mediaDir.exists()) {
+            mediaDir.mkdirs();
+        }
+        String prefix = isFrontCamera ? "temp_front_" : "temp_back_";
+        return new File(mediaDir, prefix + timestamp + ".mp4").getAbsolutePath();
+    }
+
+    private void openCameras() {
+        CameraManager manager = (CameraManager) getSystemService(Context.CAMERA_SERVICE);
+        try {
+            String frontCameraId = getFrontCameraId(manager);
+            if (frontCameraId != null) {
+                manager.openCamera(frontCameraId, new CameraDevice.StateCallback() {
+                    @Override
+                    public void onOpened(@NonNull CameraDevice camera) {
+                        frontCamera = camera;
+                        if (frontRecorder != null) {
+                            createCaptureSession(camera, frontRecorder.getSurface(), true);
+                        }
+                    }
+
+                    @Override
+                    public void onDisconnected(@NonNull CameraDevice camera) {
+                        camera.close();
+                        Log.e(TAG, "Front camera disconnected.");
+                    }
+
+                    @Override
+                    public void onError(@NonNull CameraDevice camera, int error) {
+                        camera.close();
+                        Log.e(TAG, "Error opening front camera: " + error);
+                    }
+                }, null);
+            }
+
+            // Open back camera
+            String backCameraId = getBackCameraId(manager);
+            if (backCameraId != null) {
+                manager.openCamera(backCameraId, new CameraDevice.StateCallback() {
+                    @Override
+                    public void onOpened(@NonNull CameraDevice camera) {
+                        backCamera = camera;
+                        if (backRecorder != null) {
+                            createCaptureSession(camera, backRecorder.getSurface(), false);
+                        }
+                    }
+
+                    @Override
+                    public void onDisconnected(@NonNull CameraDevice camera) {
+                        camera.close();
+                        Log.e(TAG, "Back camera disconnected.");
+                    }
+
+                    @Override
+                    public void onError(@NonNull CameraDevice camera, int error) {
+                        camera.close();
+                        Log.e(TAG, "Error opening back camera: " + error);
+                    }
+                }, null);
+            }
+        } catch (CameraAccessException | SecurityException e) {
+            Log.e(TAG, "Error accessing cameras: " + e.getMessage());
+        }
+    }
+
+    private void createCaptureSession(CameraDevice camera, Surface surface, boolean isFrontCamera) {
+        try {
+            List<Surface> surfaces = new ArrayList<>();
+            surfaces.add(surface);
+
+            camera.createCaptureSession(surfaces, new CameraCaptureSession.StateCallback() {
+                @Override
+                public void onConfigured(@NonNull CameraCaptureSession session) {
+                    try {
+                        CaptureRequest.Builder builder = camera.createCaptureRequest(CameraDevice.TEMPLATE_RECORD);
+                        builder.addTarget(surface);
+                        session.setRepeatingRequest(builder.build(), null, null);
+
+                        if (isFrontCamera) {
+                            frontSession = session;
+                            frontRecorder.start();
+                            Log.d(TAG, "Front recorder started.");
+                        } else {
+                            backSession = session;
+                            backRecorder.start();
+                            Log.d(TAG, "Back recorder started.");
+                        }
+                    } catch (CameraAccessException e) {
+                        Log.e(TAG, "Error creating capture request: " + e.getMessage());
+                    }
+                }
+
+                @Override
+                public void onConfigureFailed(@NonNull CameraCaptureSession session) {
+                    Log.e(TAG, "Failed to configure camera session.");
+                }
+            }, null);
+        } catch (CameraAccessException e) {
+            Log.e(TAG, "Error creating capture session: " + e.getMessage());
+        }
+    }
+
+    private void stopDualRecording() {
+        if (!isRecording) {
+            Log.w(TAG, "stopDualRecording: Not currently recording. Ignoring stop request.");
+            return;
+        }
+        isRecording = false;
+
+        try {
+            if (frontRecorder != null) {
+                try {
+                    frontRecorder.stop();
+                } catch (IllegalStateException e) {
+                    Log.e(TAG, "Error stopping front recorder: " + e.getMessage());
+                }
+                frontRecorder.release();
+                frontRecorder = null;
+                Log.d(TAG, "Front recorder stopped and released.");
+            }
+
+            if (backRecorder != null) {
+                try {
+                    backRecorder.stop();
+                } catch (IllegalStateException e) {
+                    Log.e(TAG, "Error stopping back recorder: " + e.getMessage());
+                }
+                backRecorder.release();
+                backRecorder = null;
+                Log.d(TAG, "Back recorder stopped and released.");
+            }
+
+            if (frontSession != null) {
+                frontSession.close();
+                frontSession = null;
+                Log.d(TAG, "Front camera session closed.");
+            }
+            if (backSession != null) {
+                backSession.close();
+                backSession = null;
+                Log.d(TAG, "Back camera session closed.");
+            }
+
+            if (frontCamera != null) {
+                frontCamera.close();
+                frontCamera = null;
+                Log.d(TAG, "Front camera closed.");
+            }
+            if (backCamera != null) {
+                backCamera.close();
+                backCamera = null;
+                Log.d(TAG, "Back camera closed.");
+            }
+
+            stopForeground(true);
+            stopSelf();
+            
+            broadcastRecordingState(false);
+
+        } catch (Exception e) {
+            Log.e(TAG, "Error stopping recording: " + e.getMessage());
+        }
+    }
+
+    private String getFrontCameraId(CameraManager manager) throws CameraAccessException {
+        for (String cameraId : manager.getCameraIdList()) {
+            if (manager.getCameraCharacteristics(cameraId).get(android.hardware.camera2.CameraCharacteristics.LENS_FACING)
+                    == android.hardware.camera2.CameraCharacteristics.LENS_FACING_FRONT) {
+                return cameraId;
+            }
+        }
+        return null;
+    }
+
+    private String getBackCameraId(CameraManager manager) throws CameraAccessException {
+        for (String cameraId : manager.getCameraIdList()) {
+            if (manager.getCameraCharacteristics(cameraId).get(android.hardware.camera2.CameraCharacteristics.LENS_FACING)
+                    == android.hardware.camera2.CameraCharacteristics.LENS_FACING_BACK) {
+                return cameraId;
+            }
+        }
+        return null;
+    }
+
+    private void startForegroundService() {
+        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle("Grabación Dual")
+                .setContentText("Grabando con ambas cámaras")
+                .setSmallIcon(R.drawable.unknown_icon3)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .build();
+
+        startForeground(NOTIFICATION_ID, notification);
     }
 
     private void createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel serviceChannel = new NotificationChannel(
+            NotificationChannel channel = new NotificationChannel(
                     CHANNEL_ID,
-                    "Recording Service Channel",
+                    "Dual Recording Service Channel",
                     NotificationManager.IMPORTANCE_LOW
             );
             NotificationManager manager = getSystemService(NotificationManager.class);
             if (manager != null) {
-                manager.createNotificationChannel(serviceChannel);
-                Log.d(TAG, "Notification channel created");
-            } else {
-                Log.e(TAG, "NotificationManager is null, unable to create notification channel");
+                manager.createNotificationChannel(channel);
             }
         }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        stopDualRecording();
+    }
+    
+    private void broadcastRecordingState(boolean recordingState) {
+        Intent intent = new Intent("RECORDING_STATE_CHANGED");
+        intent.putExtra("isRecording", recordingState);
+        sendBroadcast(intent);
     }
 }

--- a/app/src/main/java/com/fadcam/ui/HomeFragment.java
+++ b/app/src/main/java/com/fadcam/ui/HomeFragment.java
@@ -1,22 +1,6 @@
 package com.fadcam.ui;
 
-
-import android.Manifest;
-import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
-import android.os.Build;
-import android.os.PowerManager;
-import android.provider.Settings;
-import android.util.Log;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-import java.util.ArrayList;
-import java.util.List;
-
-
-
+// Importaciones de Android
 import android.Manifest;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
@@ -64,6 +48,7 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
+// Importaciones de AndroidX
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.cardview.widget.CardView;
@@ -71,14 +56,20 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
+// Importaciones de Material Components
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+// Importaciones de FFmpegKit
 import com.arthenica.ffmpegkit.ExecuteCallback;
 import com.arthenica.ffmpegkit.FFmpegKit;
 import com.arthenica.ffmpegkit.Session;
+
+// Importaciones de tu aplicación
 import com.fadcam.Constantes;
 import com.fadcam.R;
 import com.fadcam.RecordingService;
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+// Importaciones de Java
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -92,11 +83,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutorService;
+
+
+
 
 public class HomeFragment extends Fragment {
 
@@ -106,6 +103,8 @@ public class HomeFragment extends Fragment {
 
     private long recordingStartTime;
     private long videoBitrate;
+
+    private ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     private RecordsAdapter adapter;
 
@@ -170,7 +169,6 @@ public class HomeFragment extends Fragment {
 
     private static final int REQUEST_PERMISSIONS = 1;
     private android.os.PowerManager.WakeLock wakeLock;  // Full path for clarity
-//    private static final String PREF_FIRST_LAUNCH = "first_launch";
 
     // important
     private void requestEssentialPermissions() {
@@ -224,9 +222,6 @@ public class HomeFragment extends Fragment {
     }
 
     // Call this method when the recording starts to acquire wake lock
-//    private WakeLock wakeLock;
-
-    // Call this method when the recording starts to acquire wake lock
     private void acquireWakeLock() {
         android.os.PowerManager powerManager = (android.os.PowerManager) requireActivity().getSystemService(Context.POWER_SERVICE); // Full path and context adjusted
         wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyApp::RecordingLock");
@@ -244,9 +239,6 @@ public class HomeFragment extends Fragment {
             Log.d(TAG, "WakeLock released.");
         }
     }
-
-
-
 
     private void initializeMessages() {
         messageQueue = new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.easter_eggs_array)));
@@ -280,7 +272,6 @@ public class HomeFragment extends Fragment {
             tvPreviewPlaceholder.setText("Oops! No messages available right now.");
         }
     }
-
 
     private void setupLongPressListener() {
         cardPreview.setOnLongClickListener(v -> {
@@ -348,7 +339,6 @@ public class HomeFragment extends Fragment {
         });
     }
 
-
     private void updatePreviewVisibility() {
         if (isRecording) {
             if (isPreviewEnabled) {
@@ -407,16 +397,6 @@ public class HomeFragment extends Fragment {
         // Request essential permissions on every launch
         requestEssentialPermissions();
 
-        // Check if it's the first launch
-//        boolean isFirstLaunch = sharedPreferences.getBoolean(PREF_FIRST_LAUNCH, true);
-//        if (isFirstLaunch) {
-//            // Request essential permissions
-//            requestEssentialPermissions();
-//
-//            // Set first launch to false
-//            sharedPreferences.edit().putBoolean(PREF_FIRST_LAUNCH, false).apply();
-//        }
-
     }
 
     @Override
@@ -457,39 +437,10 @@ public class HomeFragment extends Fragment {
         return locationHelper.getLocationData();
     }
 
-//    @Override
-//    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-//        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-//        if (requestCode == REQUEST_PERMISSIONS) {
-//            boolean allGranted = true;
-//            for (int result : grantResults) {
-//                if (result != PackageManager.PERMISSION_GRANTED) {
-//                    allGranted = false;
-//                    break;
-//                }
-//            }
-//            if (allGranted) {
-//                startRecording();
-//            } else {
-//                Toast.makeText(requireContext(), "Essential permissions are required to start recording", Toast.LENGTH_SHORT).show();
-//            }
-//        }
-//    }
-
-
-//    private void requestLocationPermission() {
-//        if (ContextCompat.checkSelfPermission(getContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-//            ActivityCompat.requestPermissions(getActivity(), new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, LOCATION_PERMISSION_REQUEST_CODE);
-//        } else {
-//            locationHelper.startLocationUpdates();
-//        }
-//        Log.d(TAG, "Requesting location permission.");
-//    }
-
-
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         Log.d(TAG, "onCreateView: Inflating fragment_home layout");
         return inflater.inflate(R.layout.fragment_home, container, false);
     }
@@ -549,11 +500,6 @@ public class HomeFragment extends Fragment {
         // Set up long press listener for clock widget
         setupClockLongPressListener();
 
-        tvClock = view.findViewById(R.id.tvClock);
-        tvDateEnglish = view.findViewById(R.id.tvDateEnglish);
-        tvDateArabic = view.findViewById(R.id.tvDateArabic);
-
-
         cardPreview = view.findViewById(R.id.cardPreview);
         vibrator = (Vibrator) requireContext().getSystemService(Context.VIBRATOR_SERVICE);
 
@@ -561,7 +507,12 @@ public class HomeFragment extends Fragment {
         isPreviewEnabled = sharedPreferences.getBoolean("isPreviewEnabled", true);
 
         resetTimers();
-        copyFontToInternalStorage();
+
+        // Mover la copia de fuentes a un hilo de fondo
+        executorService.execute(() -> {
+            copyFontToInternalStorage();
+        });
+
         updateStorageInfo();
         updateTip();
         updateStats();
@@ -594,19 +545,19 @@ public class HomeFragment extends Fragment {
 
     private void showPermissionsInfoDialog() {
         new MaterialAlertDialogBuilder(requireContext())
-                .setTitle("Permissions Required")
-                .setMessage("This app needs camera, microphone, and storage permissions to function properly. Please enable these permissions from the app settings.")
+                .setTitle("Permisos Requeridos")
+                .setMessage("Esta aplicación necesita permisos de cámara, micrófono y almacenamiento para funcionar correctamente. Por favor, habilita estos permisos desde la configuración de la aplicación.")
                 .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
                 .show();
     }
 
     private void debugPermissionsStatus() {
-        Log.d(TAG, "Camera permission: " +
-                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED ? "Granted" : "Denied"));
-        Log.d(TAG, "Record Audio permission: " +
-                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED ? "Granted" : "Denied"));
-        Log.d(TAG, "Write External Storage permission: " +
-                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ? "Granted" : "Denied"));
+        Log.d(TAG, "Permiso de cámara: " +
+                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED ? "Concedido" : "Denegado"));
+        Log.d(TAG, "Permiso de grabar audio: " +
+                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED ? "Concedido" : "Denegado"));
+        Log.d(TAG, "Permiso de almacenamiento externo: " +
+                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ? "Concedido" : "Denegado"));
     }
 
 
@@ -804,8 +755,9 @@ public class HomeFragment extends Fragment {
         bytesAvailable -= estimatedBytesUsed;
         gbAvailable = Math.max(0, bytesAvailable / (1024.0 * 1024.0 * 1024.0));
 
-// Calculate remaining recording time based on available space and bitrate
-        long remainingTime = (videoBitrate > 0) ? (bytesAvailable * 8) / videoBitrate * 2 : 0; // Double the remaining time        // Calculate days, hours, minutes, and seconds for remaining time
+        // Calculate remaining recording time based on available space and bitrate
+        long remainingTime = (videoBitrate > 0) ? (bytesAvailable * 8) / videoBitrate * 2 : 0; // Double the remaining time
+        // Calculate days, hours, minutes, and seconds for remaining time
         long days = remainingTime / (24 * 3600);
         long hours = (remainingTime % (24 * 3600)) / 3600;
         long minutes = (remainingTime % 3600) / 60;
@@ -834,7 +786,7 @@ public class HomeFragment extends Fragment {
     private String formatRemainingTime(long days, long hours, long minutes, long seconds) {
         StringBuilder remainingTime = new StringBuilder();
         if (days > 0) {
-            remainingTime.append(String.format(Locale.getDefault(), "<font color='#E43C3C'>%d</font><font color='#CCCCCC'>days</font> ", days));
+            remainingTime.append(String.format(Locale.getDefault(), "<font color='#E43C3C'>%d</font><font color='#CCCCCC'> días</font> ", days));
         }
         if (hours > 0) {
             remainingTime.append(String.format(Locale.getDefault(), "<font color='#E43C3C'>%d</font><font color='#CCCCCC'>h</font> ", hours));
@@ -864,7 +816,7 @@ public class HomeFragment extends Fragment {
                 if (isRecording) {
                     updateStorageInfo();
                     updateStats();
-                    handler.postDelayed(this, 1000); // Update every 3 seconds
+                    handler.postDelayed(this, 1000); // Update every second
                 }
             }
         };
@@ -889,7 +841,7 @@ public class HomeFragment extends Fragment {
         currentTip = tips[currentTipIndex];
         typingIndex = 0;
         isTypingIn = true;
-//        animateTip(); this line is giving errors so i commented it
+        // Removed the commented out line
     }
 
     private void animateTip(String fullText, TextView textView, int delay) {
@@ -905,14 +857,13 @@ public class HomeFragment extends Fragment {
                     handler.postDelayed(this, 40); // add delay in typing the tips
                 } else {
                     currentTipIndex = (currentTipIndex + 1) % tips.length;
-                    handler.postDelayed(() -> animateTip(tips[currentTipIndex], textView, delay), 5000); // Wait 2 seconds before next tip
+                    handler.postDelayed(() -> animateTip(tips[currentTipIndex], textView, delay), 5000); // Wait 5 seconds before next tip
                 }
             }
         };
 
         handler.post(runnable);
     }
-
 
     private void updateStats() {
         Log.d(TAG, "updateStats: Updating video statistics");
@@ -941,22 +892,16 @@ public class HomeFragment extends Fragment {
 
     private void pauseRecording() {
         Log.d(TAG, "pauseRecording: Pausing video recording");
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            mediaRecorder.pause();
-            isPaused = true;
-            buttonPauseResume.setText(R.string.button_resume);
-            buttonPauseResume.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_play, 0, 0, 0);
-        }
+        // La pausa se maneja en el RecordingService, no en el Fragment
+        // Por lo tanto, podrías implementar una comunicación adicional si deseas pausar ambas cámaras
+        // Por simplicidad, este método muestra solo un Toast
+        Toast.makeText(getContext(), "Funcionalidad de pausar no implementada.", Toast.LENGTH_SHORT).show();
     }
 
     private void resumeRecording() {
         Log.d(TAG, "resumeRecording: Resuming video recording");
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            mediaRecorder.resume();
-            isPaused = false;
-            buttonPauseResume.setText(getString(R.string.button_pause));
-            buttonPauseResume.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_pause, 0, 0, 0);
-        }
+        // Similar a pauseRecording, manejar en el RecordingService si es necesario
+        Toast.makeText(getContext(), "Funcionalidad de reanudar no implementada.", Toast.LENGTH_SHORT).show();
     }
 
 
@@ -964,19 +909,21 @@ public class HomeFragment extends Fragment {
         @Override
         public void onReceive(Context context, Intent intent) {
             if ("RECORDING_STATE_CHANGED".equals(intent.getAction())) {
-                boolean isRecording = intent.getBooleanExtra("isRecording", false);
-                if (isRecording) {
+                boolean recordingState = intent.getBooleanExtra("isRecording", false);
+                if (recordingState) {
                     buttonStartStop.setText(getString(R.string.button_stop));
                     buttonStartStop.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_stop, 0, 0, 0);
                     buttonPauseResume.setEnabled(true);
                     tvPreviewPlaceholder.setVisibility(View.GONE);
                     textureView.setVisibility(View.VISIBLE);
+                    isRecording = true;
                 } else {
                     buttonStartStop.setText(getString(R.string.button_start));
                     buttonStartStop.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_play, 0, 0, 0);
                     buttonPauseResume.setEnabled(false);
                     tvPreviewPlaceholder.setVisibility(View.VISIBLE);
                     textureView.setVisibility(View.GONE);
+                    isRecording = false;
                 }
             }
         }
@@ -984,461 +931,245 @@ public class HomeFragment extends Fragment {
 
 
     private void startRecording() {
-        Log.d(TAG, "startRecording: Initiating video recording from home fragment");
+        Log.d(TAG, "startRecording: Initiating dual video recording");
 
-        // Acquire wake lock to prevent the device from sleeping
-        acquireWakeLock();
-
-        // Set up the camera and MediaRecorder here
-        if (!isRecording) {
-            resetTimers();
-            if (cameraDevice == null) {
-                openCamera();
-            } else {
-                startRecordingVideo();
-            }
-            recordingStartTime = SystemClock.elapsedRealtime();
-            setVideoBitrate();
-
-            buttonStartStop.setText(getString(R.string.button_stop));
-            buttonStartStop.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_stop, 0, 0, 0);
-            buttonPauseResume.setEnabled(true);
-            tvPreviewPlaceholder.setVisibility(View.GONE);
-            textureView.setVisibility(View.VISIBLE);
-
-            startUpdatingInfo();
-            isRecording = true;
-            updatePreviewVisibility();
-
-            // Start the recording service
-            Intent startIntent = new Intent(getActivity(), RecordingService.class);
-            startIntent.setAction("ACTION_START_RECORDING");
-            getActivity().startService(startIntent);
-        }
-    }
-
-
-//recording service section
-//    private void startRecording() {
-//        Log.d(TAG, "startRecording: Initiating video recording from home fragment");
-//
-//        Intent startIntent = new Intent(getActivity(), RecordingService.class);
-//        startIntent.setAction("ACTION_START_RECORDING");
-//        getActivity().startService(startIntent);
-//
-//        if (!isRecording) {
-//            resetTimers();
-//            if (cameraDevice == null) {
-//                openCamera();
-//            } else {
-//                startRecordingVideo();
-//            }
-//            recordingStartTime = SystemClock.elapsedRealtime();
-//            setVideoBitrate();
-//
-//            buttonStartStop.setText("Stop");
-//            buttonStartStop.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_stop, 0, 0, 0);
-//            buttonPauseResume.setEnabled(true);
-//            tvPreviewPlaceholder.setVisibility(View.GONE);
-//            textureView.setVisibility(View.VISIBLE);
-//
-//            startUpdatingInfo();
-//            isRecording = true;
-//            updatePreviewVisibility();
-//        }
-//    }
-
-    private void setVideoBitrate() {
-        String selectedQuality = sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
-        switch (selectedQuality) {
-            case QUALITY_SD:
-                videoBitrate = 1000000; // 1 Mbps
-                break;
-            case QUALITY_HD:
-                videoBitrate = 5000000; // 5 Mbps
-                break;
-            case QUALITY_FHD:
-                videoBitrate = 10000000; // 10 Mbps
-                break;
-            default:
-                videoBitrate = 5000000; // Default to HD
-                break;
-        }
-        Log.d(TAG, "setVideoBitrate: Set to " + videoBitrate + " bps");
-    }
-
-    private String getCameraSelection() {
-        return sharedPreferences.getString(Constantes.PREF_CAMERA_SELECTION, Constantes.CAMERA_BACK);
-    }
-
-    private String getCameraQuality() {
-        return sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
-    }
-
-    private void closeCamera() {
-        if (cameraDevice != null) {
-            cameraDevice.close();
-            cameraDevice = null;
-        }
-    }
-
-    private void openCamera() {
-        Log.d(TAG, "openCamera: Opening camera");
-        CameraManager manager = (CameraManager) getActivity().getSystemService(Context.CAMERA_SERVICE);
-        try {
-            String[] cameraIdList = manager.getCameraIdList();
-            cameraId = getCameraSelection().equals(Constantes.CAMERA_FRONT) ? cameraIdList[1] : cameraIdList[0];
-            manager.openCamera(cameraId, new CameraDevice.StateCallback() {
-                @Override
-                public void onOpened(@NonNull CameraDevice camera) {
-                    Log.d(TAG, "onOpened: Camera opened successfully");
-                    cameraDevice = camera;
-                    startRecordingVideo();
-                }
-
-                @Override
-                public void onDisconnected(@NonNull CameraDevice camera) {
-                    Log.w(TAG, "onDisconnected: Camera disconnected");
-                    cameraDevice.close();
-                }
-
-                @Override
-                public void onError(@NonNull CameraDevice camera, int error) {
-                    Log.e(TAG, "onError: Camera error: " + error);
-                    cameraDevice.close();
-                    cameraDevice = null;
-                }
-            }, null);
-        } catch (CameraAccessException | SecurityException e) {
-            Log.e(TAG, "openCamera: Error opening camera", e);
-            e.printStackTrace();
-        }
-    }
-
-    private void startRecordingVideo() {
-        Log.d(TAG, "startRecordingVideo: Setting up video recording preview area");
-        buttonCamSwitch.setEnabled(false);
-
-        // Check if TextureView is available before starting recording
-        if (!textureView.isAvailable()) {
-            tvPreviewPlaceholder.setVisibility(View.VISIBLE);
-            textureView.setVisibility(View.VISIBLE);
-            openCamera();
-            Log.e(TAG, "startRecordingVideo: TextureView is now available             550");
-        }
-
-        if (null == cameraDevice || !textureView.isAvailable() || !Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-            Log.e(TAG, "startRecordingVideo: Unable to start recording due to missing prerequisites");
+        // Check if already recording to prevent multiple starts
+        if (isRecording) {
+            Log.w(TAG, "startRecording: Already recording. Ignoring start request.");
             return;
         }
-        try {
-            Log.e(TAG, "startRecordingVideo: TextureView found, success             556+");
-            setupMediaRecorder();
-            SurfaceTexture texture = textureView.getSurfaceTexture();
-            assert texture != null;
-            texture.setDefaultBufferSize(720, 1080);
-            Surface previewSurface = new Surface(texture);
-            Surface recorderSurface = mediaRecorder.getSurface();
-            captureRequestBuilder = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_RECORD);
-// below line of code is to show the preview screen.
-//            captureRequestBuilder.addTarget(previewSurface);
-            if (isPreviewEnabled) {
-                captureRequestBuilder.addTarget(previewSurface);
-            }
-            captureRequestBuilder.addTarget(recorderSurface);
 
-            int selectedFramerate = sharedPreferences.getInt(Constantes.PREF_VIDEO_FRAMERATE, Constantes.DEFAULT_VIDEO_FRAMERATE);
+        // Acquire wake lock
+        acquireWakeLock();
 
-            // Define framerate
-            Range<Integer> fpsRange = Range.create(selectedFramerate, selectedFramerate);
-            captureRequestBuilder.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, fpsRange);
+        resetTimers();
+        setVideoBitrate();
 
-            cameraDevice.createCaptureSession(Arrays.asList(previewSurface, recorderSurface),
-                    new CameraCaptureSession.StateCallback() {
-                        @Override
-                        public void onConfigured(@NonNull CameraCaptureSession cameraCaptureSession) {
-                            Log.d(TAG, "onConfigured: Camera capture session configured");
-                            HomeFragment.this.cameraCaptureSession = cameraCaptureSession;
-                            try {
-                                cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), null, null);
-                            } catch (CameraAccessException e) {
-                                Log.e(TAG, "onConfigured: Error setting repeating request", e);
-                                e.printStackTrace();
-                            }
-                            mediaRecorder.start();
-                            getActivity().runOnUiThread(() -> {
-                                // Haptic Feedback
-                                vibrateTouch();
-                                isRecording = true;
-                                Toast.makeText(getContext(), R.string.video_recording_started, Toast.LENGTH_SHORT).show();
-                            });
-                        }
+        buttonStartStop.setText(getString(R.string.button_stop));
+        buttonStartStop.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_stop, 0, 0, 0);
+        buttonPauseResume.setEnabled(true);
+        tvPreviewPlaceholder.setVisibility(View.GONE);
+        textureView.setVisibility(View.VISIBLE);
 
-                        @Override
-                        public void onConfigureFailed(@NonNull CameraCaptureSession session) {
-                            Log.e(TAG, "onConfigureFailed: Failed to configure camera capture session");
-                            Toast.makeText(getContext(), "Failed to start recording", Toast.LENGTH_SHORT).show();
-                        }
-                    }, null);
-        } catch (CameraAccessException e) {
-            Log.e(TAG, "startRecordingVideo: Camera access exception", e);
-            e.printStackTrace();
-        }
-    }
+        startUpdatingInfo();
+        isRecording = true;
+        updatePreviewVisibility();
 
-    private void setupMediaRecorder() {
-        /*
-         * This method sets up the MediaRecorder for video recording.
-         * It creates a directory for saving videos if it doesn't exist,
-         * generates a timestamp-based filename, and configures the
-         * MediaRecorder with the appropriate settings based on the
-         * selected video quality (SD, HD, FHD). It reduces bitrates
-         * by 50% using the HEVC (H.265) encoder for efficient compression
-         * without significantly affecting video quality.
-         *
-         * - SD: 640x480 @ 0.5 Mbps
-         * - HD: 1280x720 @ 2.5 Mbps
-         * - FHD: 1920x1080 @ 5 Mbps
-         *
-         * It also adjusts the frame rate, sets audio settings, and configures
-         * the orientation based on the camera selection (front or rear).
-         */
-
-        try {
-            // Create directory for saving videos if it doesn't exist
-            File videoDir = new File(requireActivity().getExternalFilesDir(null), "FadCam");
-            if (!videoDir.exists()) {
-                videoDir.mkdirs();
-            }
-
-            // Generate a timestamp-based filename for the video
-            String timestamp = new SimpleDateFormat("yyyyMMdd_hh_mm_ssa", Locale.getDefault()).format(new Date());
-            File videoFile = new File(videoDir, "temp_" + timestamp + ".mp4");
-
-            // Initialize MediaRecorder
-            mediaRecorder = new MediaRecorder();
-            mediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
-            mediaRecorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
-            mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
-            mediaRecorder.setOutputFile(videoFile.getAbsolutePath());
-
-            // Select video quality and adjust size and bitrate
-            String selectedQuality = sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
-            switch (selectedQuality) {
-                case QUALITY_SD:
-                    // SD: 640x480 resolution, 0.5 Mbps (50% of original 1 Mbps)
-                    mediaRecorder.setVideoSize(640, 480);
-                    mediaRecorder.setVideoEncodingBitRate(500000);
-                    break;
-                case QUALITY_HD:
-                    // HD: 1280x720 resolution, 2.5 Mbps (50% of original 5 Mbps)
-                    mediaRecorder.setVideoSize(1280, 720);
-                    mediaRecorder.setVideoEncodingBitRate(2500000);
-                    break;
-                case QUALITY_FHD:
-                    // FHD: 1920x1080 resolution, 5 Mbps (50% of original 10 Mbps)
-                    mediaRecorder.setVideoSize(1920, 1080);
-                    mediaRecorder.setVideoEncodingBitRate(5000000);
-                    break;
-                default:
-                    // Default to HD settings
-                    mediaRecorder.setVideoSize(1280, 720);
-                    mediaRecorder.setVideoEncodingBitRate(2500000);
-                    break;
-            }
-
-            // Set frame rate and capture rate
-            int selectedFramerate = sharedPreferences.getInt(Constantes.PREF_VIDEO_FRAMERATE, Constantes.DEFAULT_VIDEO_FRAMERATE);
-            mediaRecorder.setVideoFrameRate(selectedFramerate);
-            mediaRecorder.setCaptureRate(selectedFramerate);
-
-            // Audio settings: high-quality audio
-            mediaRecorder.setAudioEncodingBitRate(384000);
-            mediaRecorder.setAudioSamplingRate(48000);
-            mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
-
-            // Set video encoder to HEVC (H.265) for better compression
-            mediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.HEVC);
-
-            // Set orientation based on camera selection
-            if (getCameraSelection().equals(Constantes.CAMERA_FRONT)) {
-                mediaRecorder.setOrientationHint(270);
-            } else {
-                mediaRecorder.setOrientationHint(90);
-            }
-
-            // Prepare MediaRecorder
-            mediaRecorder.prepare();
-
-        } catch (IOException e) {
-            Log.e(TAG, "setupMediaRecorder: Error setting up media recorder", e);
-            e.printStackTrace();
-        }
-    }
-
-
-    private String extractTimestamp(String filename) {
-        // Assuming filename format is "prefix_TIMESTAMP.mp4"
-        // Example: "temp_20240730_01_39_26PM.mp4"
-        // Extracting timestamp part: "20240730_01_39_26PM"
-        int startIndex = filename.indexOf('_') + 1;
-        int endIndex = filename.lastIndexOf('.');
-        return filename.substring(startIndex, endIndex);
-    }
-
-
-    private void checkAndDeleteSpecificTempFile() {
-        if (tempFileBeingProcessed != null) {
-            String tempTimestamp = extractTimestamp(tempFileBeingProcessed.getName());
-
-            // Construct FADCAM_ filename with the same timestamp
-            String outputFilePath = tempFileBeingProcessed.getParent() + "/FADCAM_" + tempFileBeingProcessed.getName().replace("temp_", "");
-            File outputFile = new File(outputFilePath);
-
-            // Check if the FADCAM_ file exists
-            if (outputFile.exists()) {
-                // Delete temp file
-                if (tempFileBeingProcessed.delete()) {
-                    Log.d(TAG, "Temp file deleted successfully.");
-                } else {
-                    Log.e(TAG, "Failed to delete temp file.");
-                }
-                // Reset tempFileBeingProcessed to null after deletion
-                tempFileBeingProcessed = null;
-            } else {
-                // FADCAM_ file does not exist yet
-                Log.d(TAG, "Matching FADCAM_ file not found. Temp file remains.");
-            }
-        }
-    }
-
-
-    private void startMonitoring() {
-        final long CHECK_INTERVAL_MS = 1000; // 1 second
-
-        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
-            checkAndDeleteSpecificTempFile();
-        }, 0, CHECK_INTERVAL_MS, TimeUnit.MILLISECONDS);
+        // Start the dual recording service
+        Intent startIntent = new Intent(getActivity(), RecordingService.class);
+        startIntent.setAction("ACTION_START_RECORDING");
+        requireActivity().startService(startIntent);
     }
 
 
     private void stopRecording() {
-        Log.d(TAG, "stopRecording: Stopping video recording");
+        Log.d(TAG, "stopRecording: Stopping dual video recording");
 
-        // Release wake lock when recording stops
-        releaseWakeLock();
-
-        // Stop the recording service
-        Intent stopIntent = new Intent(getActivity(), RecordingService.class);
-        stopIntent.setAction("ACTION_STOP_RECORDING");
-        getActivity().startService(stopIntent);
-
-        if (isRecording) {
-            try {
-                cameraCaptureSession.stopRepeating();
-                cameraCaptureSession.abortCaptures();
-                releaseCamera();
-                vibrateTouch();
-                Toast.makeText(getContext(), R.string.video_recording_stopped, Toast.LENGTH_SHORT).show();
-
-                // Add watermarking here if necessary
-                // Get the latest video file
-                File latestVideoFile = getLatestVideoFile();
-                if (latestVideoFile != null) {
-                    String inputFilePath = latestVideoFile.getAbsolutePath();
-                    String originalFileName = latestVideoFile.getName().replace("temp_", "");
-                    String outputFilePath = latestVideoFile.getParent() + "/FADCAM_" + originalFileName;
-                    Log.d(TAG, "Watermarking: Input file path: " + inputFilePath);
-                    Log.d(TAG, "Watermarking: Output file path: " + outputFilePath);
-
-                    tempFileBeingProcessed = latestVideoFile;
-                    addTextWatermarkToVideo(inputFilePath, outputFilePath);
-                } else {
-                    Log.e(TAG, "No video file found.");
-                }
-
-                isRecording = false;
-                buttonStartStop.setText(getString(R.string.button_start));
-                buttonStartStop.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_play, 0, 0, 0);
-                buttonPauseResume.setEnabled(false);
-                tvPreviewPlaceholder.setVisibility(View.VISIBLE);
-                textureView.setVisibility(View.INVISIBLE);
-                stopUpdatingInfo();
-                updateStorageInfo();
-            } catch (CameraAccessException | IllegalStateException e) {
-                Log.e(TAG, "stopRecording: Error stopping recording", e);
-                e.printStackTrace();
-            }
-            isRecording = false;
-            updatePreviewVisibility();
+        if (!isRecording) {
+            return;
         }
-        buttonCamSwitch.setEnabled(true);
+
+        try {
+            // Release wake lock
+            releaseWakeLock();
+
+            // Stop the recording service
+            Intent stopIntent = new Intent(getActivity(), RecordingService.class);
+            stopIntent.setAction("ACTION_STOP_RECORDING");
+            requireActivity().startService(stopIntent);
+
+            isRecording = false;
+            buttonStartStop.setText(getString(R.string.button_start));
+            buttonStartStop.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_play, 0, 0, 0);
+            buttonPauseResume.setEnabled(false);
+            tvPreviewPlaceholder.setVisibility(View.VISIBLE);
+            textureView.setVisibility(View.INVISIBLE);
+            stopUpdatingInfo();
+            updateStorageInfo();
+
+            // Mostrar un mensaje de que los videos se están procesando
+            Toast.makeText(getContext(),
+                    "Procesando videos, por favor espere...",
+                    Toast.LENGTH_LONG).show();
+
+            // Deshabilitar temporalmente los botones
+            buttonStartStop.setEnabled(false);
+            buttonCamSwitch.setEnabled(false);
+
+            // Procesar los videos en segundo plano
+            executorService.execute(() -> {
+                try {
+                    processLatestVideos();
+
+                    // Actualizar UI en el hilo principal
+                    new Handler(Looper.getMainLooper()).post(() -> {
+                        Toast.makeText(getContext(),
+                                "Videos guardados correctamente",
+                                Toast.LENGTH_SHORT).show();
+                        // Reactivar los botones
+                        buttonStartStop.setEnabled(true);
+                        buttonCamSwitch.setEnabled(true);
+                    });
+                } catch (Exception e) {
+                    Log.e(TAG, "Error processing videos: " + e.getMessage());
+                    new Handler(Looper.getMainLooper()).post(() -> {
+                        Toast.makeText(getContext(),
+                                "Error al procesar los videos",
+                                Toast.LENGTH_SHORT).show();
+                        // Reactivar los botones incluso si hay error
+                        buttonStartStop.setEnabled(true);
+                        buttonCamSwitch.setEnabled(true);
+                    });
+                }
+            });
+
+        } catch (Exception e) {
+            Log.e(TAG, "Error stopping recording: " + e.getMessage());
+            buttonStartStop.setEnabled(true);
+            buttonCamSwitch.setEnabled(true);
+        }
     }
 
+    // Nuevo método para procesar los últimos videos grabados
+    private void processLatestVideos() {
+        try {
+            // Esperar un poco más antes de procesar los archivos
+            Thread.sleep(3000);
 
-//recording service section
-//    private void stopRecording() {
-//        Log.d(TAG, "stopRecording: Stopping video recording");
-//
-//        Intent stopIntent = new Intent(getActivity(), RecordingService.class);
-//        stopIntent.setAction("ACTION_STOP_RECORDING");
-//        getActivity().startService(stopIntent);
-//
-//        if (isRecording) {
-//            try {
-//                cameraCaptureSession.stopRepeating();
-//                cameraCaptureSession.abortCaptures();
-//                mediaRecorder.stop();
-//                mediaRecorder.reset();
-//                // Haptic Feedback
-//                vibrateTouch();
-//                Toast.makeText(getContext(), "Recording stopped", Toast.LENGTH_SHORT).show();
-//            } catch (CameraAccessException | IllegalStateException e) {
-//                Log.e(TAG, "stopRecording: Error stopping recording", e);
-//                e.printStackTrace();
-//            }
-//// below lines are new
-//            // Add watermarking here
-//            // Get the latest video file
-//            File latestVideoFile = getLatestVideoFile();
-//            if (latestVideoFile != null) {
-//                // Prepare file paths
-//                String inputFilePath = latestVideoFile.getAbsolutePath();
-//
-//                // Remove 'temp_' prefix from the file name to get the original name
-//                String originalFileName = latestVideoFile.getName().replace("temp_", "");
-//
-//                // Create output file path with 'FADCAM_' prefix
-//                String outputFilePath = latestVideoFile.getParent() + "/FADCAM_" + originalFileName;
-//                Log.d(TAG, "Watermarking: Input file path: " + inputFilePath);
-//                Log.d(TAG, "Watermarking: Output file path: " + outputFilePath);
-//
-//                // Track the temp file being processed
-//                tempFileBeingProcessed = latestVideoFile;
-//
-//                // Add text watermark to the recorded video
-//                addTextWatermarkToVideo(inputFilePath, outputFilePath);
-//            } else {
-//                Log.e(TAG, "No video file found.");
-//            }
-//
-//
-//            releaseCamera();
-//            isRecording = false;
-//            buttonStartStop.setText("Start");
-//            buttonStartStop.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_play, 0, 0, 0);
-//            buttonPauseResume.setEnabled(false);
-//            tvPreviewPlaceholder.setVisibility(View.VISIBLE);
-//            textureView.setVisibility(View.INVISIBLE);
-//            stopUpdatingInfo();
-//            updateStorageInfo(); // Final update with actual values
-//
-//            // Start monitoring temp files
-////            startMonitoring();
-//        }
-//        isRecording = false;
-//        updatePreviewVisibility();
-//    }
+            File videoDir = new File(requireActivity().getExternalFilesDir(null), "FadCam");
+            if (!videoDir.exists() || !videoDir.isDirectory()) {
+                Log.w(TAG, "Video directory does not exist or is not a directory");
+                return;
+            }
+
+            // Obtener todos los archivos
+            File[] allFiles = videoDir.listFiles();
+            if (allFiles == null) return;
+
+            // Mapas para mantener solo el archivo más reciente de cada tipo
+            Map<String, File> latestFiles = new HashMap<>();
+            Map<String, Long> latestTimes = new HashMap<>();
+
+            // Primero, eliminar cualquier archivo temporal anterior que pudiera haber quedado
+            for (File file : allFiles) {
+                String name = file.getName();
+                if (name.startsWith("temp_")) {
+                    String type = name.contains("front_") ? "front" : "back";
+                    long modTime = file.lastModified();
+
+                    if (!latestFiles.containsKey(type) || modTime > latestTimes.get(type)) {
+                        // Si ya había un archivo anterior de este tipo, eliminarlo
+                        if (latestFiles.containsKey(type)) {
+                            File oldFile = latestFiles.get(type);
+                            if (oldFile.exists()) {
+                                oldFile.delete();
+                                Log.d(TAG, "Deleted older temp file: " + oldFile.getName());
+                            }
+                        }
+                        latestFiles.put(type, file);
+                        latestTimes.put(type, modTime);
+                    } else {
+                        // Este es un archivo más antiguo, eliminarlo
+                        file.delete();
+                        Log.d(TAG, "Deleted older temp file: " + file.getName());
+                    }
+                }
+            }
+
+            // Procesar los archivos más recientes
+            for (File file : latestFiles.values()) {
+                if (file.exists()) {
+                    String inputFilePath = file.getAbsolutePath();
+                    String originalFileName = file.getName().replace("temp_", "");
+                    String outputFilePath = file.getParent() + "/FADCAM_" + originalFileName;
+                    File outputFile = new File(outputFilePath);
+
+                    if (!outputFile.exists()) {
+                        Log.d(TAG, "Processing video: " + inputFilePath);
+                        addTextWatermarkToVideo(inputFilePath, outputFilePath, () -> {
+                            // Eliminar el archivo temporal después de procesar
+                            if (file.exists()) {
+                                file.delete();
+                                Log.d(TAG, "Deleted temp file after processing: " + file.getName());
+                            }
+                        });
+                    } else {
+                        // Si ya existe el archivo FADCAM_, eliminar el temporal
+                        file.delete();
+                        Log.d(TAG, "Deleted duplicate temp file: " + file.getName());
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            Log.e(TAG, "Error in processLatestVideos: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    // Nuevo método para procesar video y esperar a que termine
+    private void processVideoAndWait(File video) {
+        if (video == null || !video.exists()) {
+            Log.e(TAG, "Invalid video file");
+            return;
+        }
+
+        String inputFilePath = video.getAbsolutePath();
+        String originalFileName = video.getName().replace("temp_", "");
+        String outputFilePath = video.getParent() + "/FADCAM_" + originalFileName;
+        File outputFile = new File(outputFilePath);
+
+        if (outputFile.exists()) {
+            // Si ya existe el archivo FADCAM_, eliminar el temporal
+            video.delete();
+            return;
+        }
+
+        // Crear un semáforo para esperar a que termine el procesamiento
+        final Object lock = new Object();
+        final boolean[] processingComplete = {false};
+
+        addTextWatermarkToVideo(inputFilePath, outputFilePath, () -> {
+            synchronized (lock) {
+                processingComplete[0] = true;
+                lock.notify();
+            }
+        });
+
+        // Esperar a que termine el procesamiento
+        synchronized (lock) {
+            try {
+                while (!processingComplete[0]) {
+                    lock.wait(5000); // Esperar máximo 5 segundos
+                }
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Processing interrupted: " + e.getMessage());
+            }
+        }
+    }
+
+    // Nuevo método para procesar un video individual
+    private void processVideo(File video) {
+        if (video == null || !video.exists()) {
+            Log.e(TAG, "Invalid video file");
+            return;
+        }
+
+        String inputFilePath = video.getAbsolutePath();
+        String originalFileName = video.getName().replace("temp_", "");
+        String outputFilePath = video.getParent() + "/FADCAM_" + originalFileName;
+        File outputFile = new File(outputFilePath);
+
+        if (!outputFile.exists()) {
+            Log.d(TAG, "Processing video: " + inputFilePath);
+            addTextWatermarkToVideo(inputFilePath, outputFilePath, null);
+        } else {
+            Log.d(TAG, "Output file already exists, deleting temp file");
+            if (video.delete()) {
+                Log.d(TAG, "Temp file deleted: " + inputFilePath);
+            }
+        }
+    }
 
     private void releaseCamera() {
         Log.d(TAG, "releaseCamera: Releasing camera resources");
@@ -1456,20 +1187,7 @@ public class HomeFragment extends Fragment {
 
 // below methods are new
 
-    private File getLatestVideoFile() {
-        File videoDir = new File(requireActivity().getExternalFilesDir(null), "FadCam");
-        File[] files = videoDir.listFiles();
-        if (files == null || files.length == 0) {
-            return null;
-        }
-
-        // Sort files by last modified date
-        Arrays.sort(files, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
-        return files[0]; // Return the most recently modified file
-    }
-
-
-    private void addTextWatermarkToVideo(String inputFilePath, String outputFilePath) {
+    private void addTextWatermarkToVideo(String inputFilePath, String outputFilePath, Runnable onComplete) {
         String fontPath = getContext().getFilesDir().getAbsolutePath() + "/ubuntu_regular.ttf";
         String watermarkText;
         String watermarkOption = getWatermarkOption();
@@ -1479,17 +1197,17 @@ public class HomeFragment extends Fragment {
 
         switch (watermarkOption) {
             case "timestamp_fadcam":
-                watermarkText = "Captured by FadCam - " + getCurrentTimestamp() + (isLocationEnabled ? "" + locationText : "");
+                watermarkText = "Captured by FadCam - " + getCurrentTimestamp() + (isLocationEnabled ? " " + locationText : "");
                 break;
             case "timestamp":
-                watermarkText = getCurrentTimestamp() + (isLocationEnabled ? "" + locationText : "");
+                watermarkText = getCurrentTimestamp() + (isLocationEnabled ? " " + locationText : "");
                 break;
             case "no_watermark":
                 String ffmpegCommandNoWatermark = String.format("-i %s -codec copy %s", inputFilePath, outputFilePath);
                 executeFFmpegCommand(ffmpegCommandNoWatermark);
                 return;
             default:
-                watermarkText = "Captured by FadCam - " + getCurrentTimestamp() + (isLocationEnabled ? "" + locationText : "");
+                watermarkText = "Captured by FadCam - " + getCurrentTimestamp() + (isLocationEnabled ? " " + locationText : "");
                 break;
         }
 
@@ -1498,7 +1216,7 @@ public class HomeFragment extends Fragment {
 
         // Get and convert the font size to English numerals
         int fontSize = getFontSizeBasedOnBitrate();
-        String fontSizeStr = convertArabicNumeralsToEnglish(String.valueOf(fontSize));
+        String fontSizeStr = String.valueOf(fontSize); // No need to convert numerals here
 
         Log.d(TAG, "Watermark Text: " + watermarkText);
         Log.d(TAG, "Font Path: " + fontPath);
@@ -1510,17 +1228,39 @@ public class HomeFragment extends Fragment {
                 inputFilePath, watermarkText, fontSizeStr, fontPath, outputFilePath
         );
 
-        executeFFmpegCommand(ffmpegCommand);
+        // Execute the FFmpeg command asynchronously
+        FFmpegKit.executeAsync(ffmpegCommand, session -> {
+            if (session.getReturnCode().isSuccess()) {
+                Log.d(TAG, "Watermark added successfully to: " + outputFilePath);
+                // Eliminar el archivo temporal después de procesar exitosamente
+                File inputFile = new File(inputFilePath);
+                if (inputFile.exists()) {
+                    if (inputFile.delete()) {
+                        Log.d(TAG, "Temp file deleted: " + inputFilePath);
+                    }
+                }
+            } else {
+                Log.e(TAG, "Failed to add watermark: " + session.getFailStackTrace());
+            }
+
+            // Llamar al callback cuando termine
+            if (onComplete != null) {
+                onComplete.run();
+            }
+        });
     }
 
-
+    // Añadir esta sobrecarga del método
+    private void addTextWatermarkToVideo(String inputFilePath, String outputFilePath) {
+        addTextWatermarkToVideo(inputFilePath, outputFilePath, null);
+    }
 
     private int getFontSizeBasedOnBitrate() {
         int fontSize;
         int videoBitrate = getVideoBitrate(); // Ensure this method retrieves the correct bitrate based on the selected quality
 
         if (videoBitrate <= 1000000) {
-            fontSize = 12; //SD quality
+            fontSize = 12; // SD quality
         } else if (videoBitrate == 10000000) {
             fontSize = 24; // FHD quality
         } else {
@@ -1559,9 +1299,6 @@ public class HomeFragment extends Fragment {
             public void apply(Session session) {
                 if (session.getReturnCode().isSuccess()) {
                     Log.d(TAG, "Watermark added successfully.");
-                    // Start monitoring temp files
-                    startMonitoring();
-
                     // Notify the adapter to update the thumbnail
                     File latestVideo = getLatestVideoFile();
                     if (latestVideo != null) {
@@ -1613,31 +1350,12 @@ public class HomeFragment extends Fragment {
 
     private void copyFontToInternalStorage() {
         AssetManager assetManager = getContext().getAssets();
-        InputStream in = null;
-        OutputStream out = null;
-        try {
-            in = assetManager.open("ubuntu_regular.ttf");
-            File outFile = new File(getContext().getFilesDir(), "ubuntu_regular.ttf");
-            out = new FileOutputStream(outFile);
+        try (InputStream in = assetManager.open("ubuntu_regular.ttf");
+             OutputStream out = new FileOutputStream(new File(getContext().getFilesDir(), "ubuntu_regular.ttf"))) {
             copyFile(in, out);
             Log.d(TAG, "Font copied to internal storage.");
         } catch (IOException e) {
-            e.printStackTrace();
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    // NO-OP
-                }
-            }
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException e) {
-                    // NO-OP
-                }
-            }
+            Log.e(TAG, "Error copying font to internal storage: " + e.getMessage());
         }
     }
 
@@ -1722,5 +1440,91 @@ public class HomeFragment extends Fragment {
         stopUpdatingInfo();
         stopUpdatingClock();
         releaseCamera();
+        executorService.shutdown(); // Cerrar el ExecutorService
+    }
+
+    private void setVideoBitrate() {
+        String selectedQuality = sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
+        switch (selectedQuality) {
+            case QUALITY_SD:
+                videoBitrate = 1000000; // 1 Mbps
+                break;
+            case QUALITY_HD:
+                videoBitrate = 5000000; // 5 Mbps
+                break;
+            case QUALITY_FHD:
+                videoBitrate = 10000000; // 10 Mbps
+                break;
+            default:
+                videoBitrate = 5000000; // Default to HD
+                break;
+        }
+        Log.d(TAG, "setVideoBitrate: Set to " + videoBitrate + " bps");
+    }
+
+    private void startMonitoring() {
+        final long CHECK_INTERVAL_MS = 1000; // 1 segundo
+
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+            checkAndDeleteSpecificTempFile();
+        }, 0, CHECK_INTERVAL_MS, TimeUnit.MILLISECONDS);
+    }
+
+    private String getCameraSelection() {
+        return sharedPreferences.getString(Constantes.PREF_CAMERA_SELECTION, Constantes.CAMERA_BACK);
+    }
+
+    private String getCameraQuality() {
+        return sharedPreferences.getString(Constantes.PREF_VIDEO_QUALITY, QUALITY_HD);
+    }
+
+    private void checkAndDeleteSpecificTempFile() {
+        if (tempFileBeingProcessed != null) {
+            String tempTimestamp = extractTimestamp(tempFileBeingProcessed.getName());
+            String outputFilePath = tempFileBeingProcessed.getParent() + "/FADCAM_" + tempFileBeingProcessed.getName().replace("temp_", "");
+            File outputFile = new File(outputFilePath);
+
+            if (outputFile.exists()) {
+                // Si el archivo FADCAM_ existe, eliminar el archivo temporal
+                if (tempFileBeingProcessed.delete()) {
+                    Log.d(TAG, "Temp file deleted successfully: " + tempFileBeingProcessed.getName());
+                } else {
+                    Log.e(TAG, "Failed to delete temp file: " + tempFileBeingProcessed.getName());
+                }
+                tempFileBeingProcessed = null;
+            } else {
+                Log.d(TAG, "Matching FADCAM_ file not found yet. Temp file remains: " + tempFileBeingProcessed.getName());
+            }
+        }
+    }
+
+    private String extractTimestamp(String filename) {
+        // Asumiendo formato de nombre: "temp_TYPE_TIMESTAMP.mp4"
+        // donde TYPE puede ser "front" o "back"
+        int startIndex = filename.lastIndexOf('_') + 1;
+        int endIndex = filename.lastIndexOf('.');
+        if (startIndex < endIndex) {
+            return filename.substring(startIndex, endIndex);
+        }
+        return "";
+    }
+
+    private File getLatestVideoFile() {
+        File videoDir = new File(requireActivity().getExternalFilesDir(null), "FadCam");
+        if (!videoDir.exists()) {
+            return null;
+        }
+
+        File[] files = videoDir.listFiles((dir, name) ->
+                name != null && name.startsWith("temp_"));
+
+        if (files == null || files.length == 0) {
+            return null;
+        }
+
+        // Ordenar por fecha de modificación (más reciente primero)
+        Arrays.sort(files, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
+
+        return files[0]; // Retornar el archivo más reciente
     }
 }

--- a/app/src/main/java/com/fadcam/ui/HomeFragment.java
+++ b/app/src/main/java/com/fadcam/ui/HomeFragment.java
@@ -1,6 +1,6 @@
 package com.fadcam.ui;
 
-// Importaciones de Android
+// Android imports
 import android.Manifest;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
@@ -48,7 +48,7 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
-// Importaciones de AndroidX
+// AndroidX imports
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.cardview.widget.CardView;
@@ -56,20 +56,20 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
-// Importaciones de Material Components
+// Material Components imports
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
-// Importaciones de FFmpegKit
+// FFmpegKit imports
 import com.arthenica.ffmpegkit.ExecuteCallback;
 import com.arthenica.ffmpegkit.FFmpegKit;
 import com.arthenica.ffmpegkit.Session;
 
-// Importaciones de tu aplicación
+// Your app imports
 import com.fadcam.Constantes;
 import com.fadcam.R;
 import com.fadcam.RecordingService;
 
-// Importaciones de Java
+// Java imports
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -91,9 +91,6 @@ import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ExecutorService;
-
-
-
 
 public class HomeFragment extends Fragment {
 
@@ -156,11 +153,9 @@ public class HomeFragment extends Fragment {
     private TextView tvTip;
     private String[] tips;
 
-
     private int currentTipIndex = 0;
 
     private TextView tvStats;
-
 
     private List<String> messageQueue;
     private List<String> recentlyShownMessages;
@@ -170,7 +165,7 @@ public class HomeFragment extends Fragment {
     private static final int REQUEST_PERMISSIONS = 1;
     private android.os.PowerManager.WakeLock wakeLock;  // Full path for clarity
 
-    // important
+    // Important
     private void requestEssentialPermissions() {
         Log.d(TAG, "requestEssentialPermissions: Requesting essential permissions");
         String[] permissions;
@@ -308,7 +303,6 @@ public class HomeFragment extends Fragment {
                 // Show random funny message
                 showRandomMessage();
 
-
                 // Ensure the placeholder is visible
                 tvPreviewPlaceholder.setVisibility(View.VISIBLE);
                 tvPreviewPlaceholder.setPadding(16, tvPreviewPlaceholder.getPaddingTop(), 16, tvPreviewPlaceholder.getPaddingBottom());
@@ -396,7 +390,6 @@ public class HomeFragment extends Fragment {
 
         // Request essential permissions on every launch
         requestEssentialPermissions();
-
     }
 
     @Override
@@ -461,7 +454,7 @@ public class HomeFragment extends Fragment {
         editor.apply();
     }
 
-    //    function to use haptic feedbacks
+    // Function to use haptic feedbacks
     private void vibrateTouch() {
         // Haptic Feedback
         Vibrator vibrator = (Vibrator) getContext().getSystemService(Context.VIBRATOR_SERVICE);
@@ -508,7 +501,7 @@ public class HomeFragment extends Fragment {
 
         resetTimers();
 
-        // Mover la copia de fuentes a un hilo de fondo
+        // Move font copying to a background thread
         executorService.execute(() -> {
             copyFontToInternalStorage();
         });
@@ -545,21 +538,20 @@ public class HomeFragment extends Fragment {
 
     private void showPermissionsInfoDialog() {
         new MaterialAlertDialogBuilder(requireContext())
-                .setTitle("Permisos Requeridos")
-                .setMessage("Esta aplicación necesita permisos de cámara, micrófono y almacenamiento para funcionar correctamente. Por favor, habilita estos permisos desde la configuración de la aplicación.")
+                .setTitle("Required Permissions")
+                .setMessage("This app needs camera, microphone, and storage permissions to function properly. Please enable these permissions from the app settings.")
                 .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
                 .show();
     }
 
     private void debugPermissionsStatus() {
-        Log.d(TAG, "Permiso de cámara: " +
-                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED ? "Concedido" : "Denegado"));
-        Log.d(TAG, "Permiso de grabar audio: " +
-                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED ? "Concedido" : "Denegado"));
-        Log.d(TAG, "Permiso de almacenamiento externo: " +
-                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ? "Concedido" : "Denegado"));
+        Log.d(TAG, "Camera permission: " +
+                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED ? "Granted" : "Denied"));
+        Log.d(TAG, "Record audio permission: " +
+                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED ? "Granted" : "Denied"));
+        Log.d(TAG, "External storage permission: " +
+                (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED ? "Granted" : "Denied"));
     }
-
 
     private void setupButtonListeners() {
         buttonStartStop.setOnClickListener(v -> {
@@ -623,7 +615,6 @@ public class HomeFragment extends Fragment {
         });
     }
 
-
     private void addWobbleAnimation() {
         // Define the scale down and scale up values
         float scaleDown = 0.9f;
@@ -673,7 +664,6 @@ public class HomeFragment extends Fragment {
         scaleDownSet.start();
     }
 
-
     private void showDisplayOptionsDialog() {
         new MaterialAlertDialogBuilder(getContext())
                 .setTitle(getString(R.string.dialog_clock_title))
@@ -702,12 +692,10 @@ public class HomeFragment extends Fragment {
         editor.apply();
     }
 
-
     private void showOptionsAndAnimate() {
         addWobbleAnimation();
         showDisplayOptionsDialog();
     }
-
 
     // Method to update the clock and dates
     private void updateClock() {
@@ -737,7 +725,6 @@ public class HomeFragment extends Fragment {
 
         tvDateArabic.setText(displayOption == 2 ? currentDateArabic : "");
     }
-
 
     private void updateStorageInfo() {
         Log.d(TAG, "updateStorageInfo: Updating storage information");
@@ -786,7 +773,7 @@ public class HomeFragment extends Fragment {
     private String formatRemainingTime(long days, long hours, long minutes, long seconds) {
         StringBuilder remainingTime = new StringBuilder();
         if (days > 0) {
-            remainingTime.append(String.format(Locale.getDefault(), "<font color='#E43C3C'>%d</font><font color='#CCCCCC'> días</font> ", days));
+            remainingTime.append(String.format(Locale.getDefault(), "<font color='#E43C3C'>%d</font><font color='#CCCCCC'> days</font> ", days));
         }
         if (hours > 0) {
             remainingTime.append(String.format(Locale.getDefault(), "<font color='#E43C3C'>%d</font><font color='#CCCCCC'>h</font> ", hours));
@@ -807,7 +794,7 @@ public class HomeFragment extends Fragment {
         return String.format(Locale.getDefault(), "%d h %d min", recordingHours, recordingMinutes);
     }
 
-    //    update storage and stats in real time while recording is started
+    // Update storage and stats in real time while recording is started
     private void startUpdatingInfo() {
         Log.d(TAG, "startUpdatingInfo: Beginning real-time updates");
         updateInfoRunnable = new Runnable() {
@@ -892,18 +879,17 @@ public class HomeFragment extends Fragment {
 
     private void pauseRecording() {
         Log.d(TAG, "pauseRecording: Pausing video recording");
-        // La pausa se maneja en el RecordingService, no en el Fragment
-        // Por lo tanto, podrías implementar una comunicación adicional si deseas pausar ambas cámaras
-        // Por simplicidad, este método muestra solo un Toast
-        Toast.makeText(getContext(), "Funcionalidad de pausar no implementada.", Toast.LENGTH_SHORT).show();
+        // Pause is handled in the RecordingService, not in the Fragment
+        // Therefore, you could implement additional communication if you want to pause both cameras
+        // For simplicity, this method only shows a Toast
+        Toast.makeText(getContext(), "Pause functionality not implemented.", Toast.LENGTH_SHORT).show();
     }
 
     private void resumeRecording() {
         Log.d(TAG, "resumeRecording: Resuming video recording");
-        // Similar a pauseRecording, manejar en el RecordingService si es necesario
-        Toast.makeText(getContext(), "Funcionalidad de reanudar no implementada.", Toast.LENGTH_SHORT).show();
+        // Similar to pauseRecording, handle in the RecordingService if necessary
+        Toast.makeText(getContext(), "Resume functionality not implemented.", Toast.LENGTH_SHORT).show();
     }
-
 
     private BroadcastReceiver recordingStateReceiver = new BroadcastReceiver() {
         @Override
@@ -928,7 +914,6 @@ public class HomeFragment extends Fragment {
             }
         }
     };
-
 
     private void startRecording() {
         Log.d(TAG, "startRecording: Initiating dual video recording");
@@ -961,7 +946,6 @@ public class HomeFragment extends Fragment {
         requireActivity().startService(startIntent);
     }
 
-
     private void stopRecording() {
         Log.d(TAG, "stopRecording: Stopping dual video recording");
 
@@ -987,26 +971,26 @@ public class HomeFragment extends Fragment {
             stopUpdatingInfo();
             updateStorageInfo();
 
-            // Mostrar un mensaje de que los videos se están procesando
+            // Show a message that the videos are being processed
             Toast.makeText(getContext(),
-                    "Procesando videos, por favor espere...",
+                    "Processing videos, please wait...",
                     Toast.LENGTH_LONG).show();
 
-            // Deshabilitar temporalmente los botones
+            // Temporarily disable buttons
             buttonStartStop.setEnabled(false);
             buttonCamSwitch.setEnabled(false);
 
-            // Procesar los videos en segundo plano
+            // Process the videos in the background
             executorService.execute(() -> {
                 try {
                     processLatestVideos();
 
-                    // Actualizar UI en el hilo principal
+                    // Update UI on the main thread
                     new Handler(Looper.getMainLooper()).post(() -> {
                         Toast.makeText(getContext(),
-                                "Videos guardados correctamente",
+                                "Videos saved successfully",
                                 Toast.LENGTH_SHORT).show();
-                        // Reactivar los botones
+                        // Reactivate buttons
                         buttonStartStop.setEnabled(true);
                         buttonCamSwitch.setEnabled(true);
                     });
@@ -1014,9 +998,9 @@ public class HomeFragment extends Fragment {
                     Log.e(TAG, "Error processing videos: " + e.getMessage());
                     new Handler(Looper.getMainLooper()).post(() -> {
                         Toast.makeText(getContext(),
-                                "Error al procesar los videos",
+                                "Error processing videos",
                                 Toast.LENGTH_SHORT).show();
-                        // Reactivar los botones incluso si hay error
+                        // Reactivate buttons even if there is an error
                         buttonStartStop.setEnabled(true);
                         buttonCamSwitch.setEnabled(true);
                     });
@@ -1030,10 +1014,10 @@ public class HomeFragment extends Fragment {
         }
     }
 
-    // Nuevo método para procesar los últimos videos grabados
+    // New method to process the latest recorded videos
     private void processLatestVideos() {
         try {
-            // Esperar un poco más antes de procesar los archivos
+            // Wait a little longer before processing the files
             Thread.sleep(3000);
 
             File videoDir = new File(requireActivity().getExternalFilesDir(null), "FadCam");
@@ -1042,15 +1026,15 @@ public class HomeFragment extends Fragment {
                 return;
             }
 
-            // Obtener todos los archivos
+            // Get all files
             File[] allFiles = videoDir.listFiles();
             if (allFiles == null) return;
 
-            // Mapas para mantener solo el archivo más reciente de cada tipo
+            // Maps to keep only the most recent file of each type
             Map<String, File> latestFiles = new HashMap<>();
             Map<String, Long> latestTimes = new HashMap<>();
 
-            // Primero, eliminar cualquier archivo temporal anterior que pudiera haber quedado
+            // First, delete any previous temporary files that might have been left
             for (File file : allFiles) {
                 String name = file.getName();
                 if (name.startsWith("temp_")) {
@@ -1058,7 +1042,7 @@ public class HomeFragment extends Fragment {
                     long modTime = file.lastModified();
 
                     if (!latestFiles.containsKey(type) || modTime > latestTimes.get(type)) {
-                        // Si ya había un archivo anterior de este tipo, eliminarlo
+                        // If there was already a previous file of this type, delete it
                         if (latestFiles.containsKey(type)) {
                             File oldFile = latestFiles.get(type);
                             if (oldFile.exists()) {
@@ -1069,14 +1053,14 @@ public class HomeFragment extends Fragment {
                         latestFiles.put(type, file);
                         latestTimes.put(type, modTime);
                     } else {
-                        // Este es un archivo más antiguo, eliminarlo
+                        // This is an older file, delete it
                         file.delete();
                         Log.d(TAG, "Deleted older temp file: " + file.getName());
                     }
                 }
             }
 
-            // Procesar los archivos más recientes
+            // Process the most recent files
             for (File file : latestFiles.values()) {
                 if (file.exists()) {
                     String inputFilePath = file.getAbsolutePath();
@@ -1087,14 +1071,14 @@ public class HomeFragment extends Fragment {
                     if (!outputFile.exists()) {
                         Log.d(TAG, "Processing video: " + inputFilePath);
                         addTextWatermarkToVideo(inputFilePath, outputFilePath, () -> {
-                            // Eliminar el archivo temporal después de procesar
+                            // Delete the temporary file after processing
                             if (file.exists()) {
                                 file.delete();
                                 Log.d(TAG, "Deleted temp file after processing: " + file.getName());
                             }
                         });
                     } else {
-                        // Si ya existe el archivo FADCAM_, eliminar el temporal
+                        // If the FADCAM_ file already exists, delete the temp
                         file.delete();
                         Log.d(TAG, "Deleted duplicate temp file: " + file.getName());
                     }
@@ -1107,7 +1091,7 @@ public class HomeFragment extends Fragment {
         }
     }
 
-    // Nuevo método para procesar video y esperar a que termine
+    // New method to process video and wait for it to finish
     private void processVideoAndWait(File video) {
         if (video == null || !video.exists()) {
             Log.e(TAG, "Invalid video file");
@@ -1120,12 +1104,12 @@ public class HomeFragment extends Fragment {
         File outputFile = new File(outputFilePath);
 
         if (outputFile.exists()) {
-            // Si ya existe el archivo FADCAM_, eliminar el temporal
+            // If the FADCAM_ file already exists, delete the temp
             video.delete();
             return;
         }
 
-        // Crear un semáforo para esperar a que termine el procesamiento
+        // Create a semaphore to wait for processing to finish
         final Object lock = new Object();
         final boolean[] processingComplete = {false};
 
@@ -1136,11 +1120,11 @@ public class HomeFragment extends Fragment {
             }
         });
 
-        // Esperar a que termine el procesamiento
+        // Wait for processing to finish
         synchronized (lock) {
             try {
                 while (!processingComplete[0]) {
-                    lock.wait(5000); // Esperar máximo 5 segundos
+                    lock.wait(5000); // Wait a maximum of 5 seconds
                 }
             } catch (InterruptedException e) {
                 Log.e(TAG, "Processing interrupted: " + e.getMessage());
@@ -1148,7 +1132,7 @@ public class HomeFragment extends Fragment {
         }
     }
 
-    // Nuevo método para procesar un video individual
+    // New method to process an individual video
     private void processVideo(File video) {
         if (video == null || !video.exists()) {
             Log.e(TAG, "Invalid video file");
@@ -1185,7 +1169,7 @@ public class HomeFragment extends Fragment {
         captureRequestBuilder = null;
     }
 
-// below methods are new
+    // Below methods are new
 
     private void addTextWatermarkToVideo(String inputFilePath, String outputFilePath, Runnable onComplete) {
         String fontPath = getContext().getFilesDir().getAbsolutePath() + "/ubuntu_regular.ttf";
@@ -1232,7 +1216,7 @@ public class HomeFragment extends Fragment {
         FFmpegKit.executeAsync(ffmpegCommand, session -> {
             if (session.getReturnCode().isSuccess()) {
                 Log.d(TAG, "Watermark added successfully to: " + outputFilePath);
-                // Eliminar el archivo temporal después de procesar exitosamente
+                // Delete the temporary file after successful processing
                 File inputFile = new File(inputFilePath);
                 if (inputFile.exists()) {
                     if (inputFile.delete()) {
@@ -1243,14 +1227,14 @@ public class HomeFragment extends Fragment {
                 Log.e(TAG, "Failed to add watermark: " + session.getFailStackTrace());
             }
 
-            // Llamar al callback cuando termine
+            // Call the callback when finished
             if (onComplete != null) {
                 onComplete.run();
             }
         });
     }
 
-    // Añadir esta sobrecarga del método
+    // Add this method overload
     private void addTextWatermarkToVideo(String inputFilePath, String outputFilePath) {
         addTextWatermarkToVideo(inputFilePath, outputFilePath, null);
     }
@@ -1319,12 +1303,10 @@ public class HomeFragment extends Fragment {
         }
     }
 
-
     private String getCurrentTimestamp() {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MMM/yyyy hh-mm a", Locale.ENGLISH);
         return convertArabicNumeralsToEnglish(sdf.format(new Date()));
     }
-
 
     private String convertArabicNumeralsToEnglish(String text) {
         if (text == null) return null;
@@ -1340,13 +1322,10 @@ public class HomeFragment extends Fragment {
                 .replaceAll("٩", "9");
     }
 
-
-
     private String getWatermarkOption() {
         SharedPreferences sharedPreferences = requireActivity().getPreferences(Context.MODE_PRIVATE);
         return sharedPreferences.getString("watermark_option", "timestamp_fadcam");
     }
-
 
     private void copyFontToInternalStorage() {
         AssetManager assetManager = getContext().getAssets();
@@ -1358,7 +1337,6 @@ public class HomeFragment extends Fragment {
             Log.e(TAG, "Error copying font to internal storage: " + e.getMessage());
         }
     }
-
 
     public void switchCamera() {
         String currentCameraSelection = sharedPreferences.getString(Constantes.PREF_CAMERA_SELECTION, Constantes.CAMERA_BACK);
@@ -1373,32 +1351,6 @@ public class HomeFragment extends Fragment {
         }
     }
 
-//    private class LocationHelper implements LocationListener {
-//
-//        private LocationManager locationManager;
-//        private double latitude;
-//        private double longitude;
-//
-//        public LocationHelper(LocationManager locationManager) {
-//            this.locationManager = locationManager;
-//        }
-//
-//        public void startListening() {
-//            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
-//        }
-//
-//        @Override
-//        public void onLocationChanged(Location location) {
-//            latitude = location.getLatitude();
-//            longitude = location.getLongitude();
-//        }
-//
-//        public String getLocationText() {
-//            return String.format(Locale.getDefault(), "%.2f, %.2f", latitude, longitude);
-//        }
-//    }
-
-
     private void copyFile(InputStream in, OutputStream out) throws IOException {
         byte[] buffer = new byte[1024];
         int read;
@@ -1407,31 +1359,23 @@ public class HomeFragment extends Fragment {
         }
     }
 
-    private void setupStartStopButton()
-    {
+    private void setupStartStopButton() {
         if (!CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_1080P) && getCameraSelection().equals(Constantes.CAMERA_FRONT) && getCameraQuality().equals(QUALITY_FHD)) {
             buttonStartStop.setEnabled(false);
-        }
-        else if (!CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_720P) && getCameraSelection().equals(Constantes.CAMERA_FRONT) && getCameraQuality().equals(QUALITY_HD)) {
+        } else if (!CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_720P) && getCameraSelection().equals(Constantes.CAMERA_FRONT) && getCameraQuality().equals(QUALITY_HD)) {
             buttonStartStop.setEnabled(false);
-        }
-        else if (!CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_VGA) && !CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_480P) && getCameraSelection().equals(Constantes.CAMERA_FRONT) && getCameraQuality().equals(QUALITY_SD)) {
+        } else if (!CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_VGA) && !CamcorderProfile.hasProfile(1, CamcorderProfile.QUALITY_480P) && getCameraSelection().equals(Constantes.CAMERA_FRONT) && getCameraQuality().equals(QUALITY_SD)) {
             buttonStartStop.setEnabled(false);
-        }
-        else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_1080P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_FHD)) {
+        } else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_1080P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_FHD)) {
             buttonStartStop.setEnabled(false);
-        }
-        else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_720P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_HD)) {
+        } else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_720P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_HD)) {
             buttonStartStop.setEnabled(false);
-        }
-        else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_VGA) && !CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_480P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_SD)) {
+        } else if (!CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_VGA) && !CamcorderProfile.hasProfile(0, CamcorderProfile.QUALITY_480P) && getCameraSelection().equals(Constantes.CAMERA_BACK) && getCameraQuality().equals(QUALITY_SD)) {
             buttonStartStop.setEnabled(false);
-        }
-        else {
+        } else {
             buttonStartStop.setEnabled(true);
         }
     }
-
 
     @Override
     public void onDestroyView() {
@@ -1440,7 +1384,7 @@ public class HomeFragment extends Fragment {
         stopUpdatingInfo();
         stopUpdatingClock();
         releaseCamera();
-        executorService.shutdown(); // Cerrar el ExecutorService
+        executorService.shutdown(); // Close the ExecutorService
     }
 
     private void setVideoBitrate() {
@@ -1463,7 +1407,7 @@ public class HomeFragment extends Fragment {
     }
 
     private void startMonitoring() {
-        final long CHECK_INTERVAL_MS = 1000; // 1 segundo
+        final long CHECK_INTERVAL_MS = 1000; // 1 second
 
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
             checkAndDeleteSpecificTempFile();
@@ -1485,7 +1429,7 @@ public class HomeFragment extends Fragment {
             File outputFile = new File(outputFilePath);
 
             if (outputFile.exists()) {
-                // Si el archivo FADCAM_ existe, eliminar el archivo temporal
+                // If the FADCAM_ file exists, delete the temp file
                 if (tempFileBeingProcessed.delete()) {
                     Log.d(TAG, "Temp file deleted successfully: " + tempFileBeingProcessed.getName());
                 } else {
@@ -1499,8 +1443,8 @@ public class HomeFragment extends Fragment {
     }
 
     private String extractTimestamp(String filename) {
-        // Asumiendo formato de nombre: "temp_TYPE_TIMESTAMP.mp4"
-        // donde TYPE puede ser "front" o "back"
+        // Assuming name format: "temp_TYPE_TIMESTAMP.mp4"
+        // where TYPE can be "front" or "back"
         int startIndex = filename.lastIndexOf('_') + 1;
         int endIndex = filename.lastIndexOf('.');
         if (startIndex < endIndex) {
@@ -1522,9 +1466,9 @@ public class HomeFragment extends Fragment {
             return null;
         }
 
-        // Ordenar por fecha de modificación (más reciente primero)
+        // Sort by modification date (most recent first)
         Arrays.sort(files, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
 
-        return files[0]; // Retornar el archivo más reciente
+        return files[0]; // Return the most recent file
     }
 }

--- a/app/src/main/java/com/fadcam/ui/SettingsFragment.java
+++ b/app/src/main/java/com/fadcam/ui/SettingsFragment.java
@@ -102,7 +102,7 @@ public class SettingsFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        // Registrar el receptor con try-catch
+        // Register receiver with try-catch
         try {
             IntentFilter filter = new IntentFilter("CAMERA_SELECTION_CHANGED");
             requireActivity().registerReceiver(cameraSelectionReceiver, filter);
@@ -115,7 +115,7 @@ public class SettingsFragment extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
-        // Desregistrar el receptor con try-catch
+        // Unregister receiver with try-catch
         try {
             if (cameraSelectionReceiver != null) {
                 requireActivity().unregisterReceiver(cameraSelectionReceiver);
@@ -146,7 +146,7 @@ public class SettingsFragment extends Fragment {
         buttonFrontCamera = view.findViewById(R.id.button_front_camera);
         buttonDualCamera = view.findViewById(R.id.button_dual_camera);
 
-        // Configurar el estado inicial basado en las preferencias guardadas
+        // Configure initial state based on saved preferences
         String currentCamera = sharedPreferences.getString(Constantes.PREF_CAMERA_SELECTION, Constantes.CAMERA_BACK);
         switch (currentCamera) {
             case Constantes.CAMERA_FRONT:
@@ -160,7 +160,7 @@ public class SettingsFragment extends Fragment {
                 break;
         }
 
-        // Configurar listener para los cambios de selección
+        // Configure listener for selection changes
         cameraSelectionToggle.addOnButtonCheckedListener((group, checkedId, isChecked) -> {
             if (isChecked) {
                 String selection;
@@ -383,7 +383,7 @@ public class SettingsFragment extends Fragment {
         String currentCameraSelection = sharedPreferences.getString(Constantes.PREF_CAMERA_SELECTION, Constantes.CAMERA_BACK);
         Log.d("SettingsFragment", "Current camera selection: " + currentCameraSelection);
 
-        // Actualizar el estado de los botones
+        // Update button states
         switch (currentCameraSelection) {
             case Constantes.CAMERA_FRONT:
                 cameraSelectionToggle.check(R.id.button_front_camera);

--- a/app/src/main/res/drawable/ic_camera_dual.xml
+++ b/app/src/main/res/drawable/ic_camera_dual.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M20,4h-3.17L15,2L9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,15m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M8.5,10.5m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M15.5,10.5m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+</vector> 

--- a/app/src/main/res/drawable/ic_camera_front.xml
+++ b/app/src/main/res/drawable/ic_camera_front.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M10,20L5,20v2h5v2l3,-3 -3,-3v2zM14,20v2h5v-2h-5zM17,0L7,0C5.9,0 5,0.9 5,2v14c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2L19,2c0,-1.1 -0.9,-2 -2,-2zM12,6c-1.11,0 -2,-0.9 -2,-2s0.89,-2 1.99,-2 2,0.9 2,2C14,5.1 13.1,6 12,6z"/>
+</vector> 

--- a/app/src/main/res/drawable/ic_camera_rear.xml
+++ b/app/src/main/res/drawable/ic_camera_rear.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M10,20L5,20v2h5v2l3,-3 -3,-3v2zM14,20v2h5v-2h-5zM17,0L7,0C5.9,0 5,0.9 5,2v14c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2L19,2c0,-1.1 -0.9,-2 -2,-2zM12,7c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z"/>
+</vector> 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -288,17 +288,6 @@
             android:text="@string/button_pause" />
             android:enabled="false"/>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonCamSwitch"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_marginStart="8dp"
-            app:icon="@drawable/cam_switch"
-            app:iconSize="24dp"
-            android:paddingLeft="12dp"
-            android:paddingRight="0dp"
-            app:cornerRadius="15dp" />
-
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -176,6 +176,15 @@
                         app:iconGravity="textStart"
                         app:iconPadding="8dp" />
 
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/button_dual_camera"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/button_settings_cam_dual"
+                        app:iconGravity="textStart"
+                        app:iconPadding="8dp" />
+
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 
             </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="note_cam_sele">Select camera \n(Default: Back)</string>
     <string name="button_settings_cam_back">Back</string>
     <string name="button_settings_cam_front">Front</string>
+    <string name="button_settings_cam_dual">Dual</string>
     <string name="setting_quailty_title">Video Quality</string>
     <string name="setting_framerate_title">Video Framerate</string>
     <string name="note_quailty">Choose quality\n(Default: HD)</string>
@@ -203,4 +204,5 @@
     <string name="delete_all_videos_description">Are you sure you want to delete all videos?</string>
     <string name="switched_front_camera">Switched to front camera</string>
     <string name="switched_rear_camera">Switched to rear camera</string>
+    <string name="switched_dual_camera">Switched to dual camera mode</string>
 </resources>


### PR DESCRIPTION
This update adds the ability to record simultaneously with both front and rear cameras. Users could now toggle between single and dual camera modes.

Changes:

- Mode Toggle: Added a button and supporting logic to switch between single and dual camera recording modes.
- Dual Camera Functionality: Implemented dual camera management to handle recording from both cameras at the same time.
- **Temporary UI Adjustment: Camera previews have been temporarily removed until a layout for displaying both camera feeds is finalized.**

Testing:

- Devices Tested: Android Studio emulator (API 34) and a real Google Pixel 8 Pro.
- Features Confirmed: Verified successful simultaneous recording and correct storage of dual-camera videos.
