### PR TITLE
Guard the external link launch in the What's New screen

### DIFF
--- a/app/src/main/java/com/fadcam/ui/WhatsNewActivity.java
+++ b/app/src/main/java/com/fadcam/ui/WhatsNewActivity.java
@@ -4,6 +4,8 @@ import com.fadcam.Log;
 import com.fadcam.FLog;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ActivityNotFoundException;
+import android.widget.Toast;
 import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.os.Bundle;
@@ -84,7 +86,11 @@ public class WhatsNewActivity extends AppCompatActivity {
                     if (url.startsWith("http://") || url.startsWith("https://")) {
                         Intent intent = new Intent(Intent.ACTION_VIEW);
                         intent.setData(Uri.parse(url));
-                        startActivity(intent);
+                        try {
+                            startActivity(intent);
+                        } catch (ActivityNotFoundException e) {
+                            Toast.makeText(view.getContext(), "No app found to open this link", Toast.LENGTH_SHORT).show();
+                        }
                         return true;
                     }
                     return false;


### PR DESCRIPTION
This wraps the external link launch in the What's New screen so the app no longer crashes when there is no app available to open the link.

Before, an http or https link was passed to `startActivity` directly, which throws `ActivityNotFoundException` on a device with no handler and takes the screen down. With this change the link still opens when a handler exists, and otherwise the exception is caught and a short message is shown.

Closes #301.