### PR TITLE
Add state-aware Toggle Recording app shortcut

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -333,6 +333,7 @@
 
         <activity android:name=".RecordingStartActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:excludeFromRecents="true" android:noHistory="true" android:exported="true" android:configChanges="keyboardHidden|orientation|screenSize" android:windowSoftInputMode="stateAlwaysHidden" android:screenOrientation="portrait" />
         <activity android:name=".RecordingStopActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:excludeFromRecents="true" android:noHistory="true" android:exported="true" android:configChanges="keyboardHidden|orientation|screenSize" android:windowSoftInputMode="stateAlwaysHidden" android:screenOrientation="portrait" />
+        <activity android:name=".RecordingToggleActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:excludeFromRecents="true" android:noHistory="true" android:exported="true" android:configChanges="keyboardHidden|orientation|screenSize" android:windowSoftInputMode="stateAlwaysHidden" android:screenOrientation="portrait" />
         <activity
             android:name=".PhotoCaptureActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -333,7 +333,7 @@
 
         <activity android:name=".RecordingStartActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:excludeFromRecents="true" android:noHistory="true" android:exported="true" android:configChanges="keyboardHidden|orientation|screenSize" android:windowSoftInputMode="stateAlwaysHidden" android:screenOrientation="portrait" />
         <activity android:name=".RecordingStopActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:excludeFromRecents="true" android:noHistory="true" android:exported="true" android:configChanges="keyboardHidden|orientation|screenSize" android:windowSoftInputMode="stateAlwaysHidden" android:screenOrientation="portrait" />
-        <activity android:name=".RecordingToggleActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:excludeFromRecents="true" android:noHistory="true" android:exported="true" android:configChanges="keyboardHidden|orientation|screenSize" android:windowSoftInputMode="stateAlwaysHidden" android:screenOrientation="portrait" />
+        <activity android:name=".RecordingToggleActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:excludeFromRecents="true" android:noHistory="true" android:exported="true" />
         <activity
             android:name=".PhotoCaptureActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"

--- a/app/src/main/java/com/fadcam/MainActivity.java
+++ b/app/src/main/java/com/fadcam/MainActivity.java
@@ -4,11 +4,8 @@ import com.fadcam.FLog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.ShortcutInfo;
-import android.content.pm.ShortcutManager;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.drawable.Icon;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -22,6 +19,7 @@ import android.view.ViewConfiguration;
 import android.widget.Toast;
 import android.widget.ImageView;
 import com.fadcam.ui.OverlayNavUtil;
+import com.fadcam.shortcuts.ShortcutsManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
@@ -920,46 +918,7 @@ public class MainActivity extends AppCompatActivity {
 
     @RequiresApi(api = Build.VERSION_CODES.N_MR1)
     private void createDynamicShortcuts() {
-        ShortcutManager shortcutManager = getSystemService(ShortcutManager.class);
-
-        // Torch Toggle Shortcut
-        Intent torchIntent = new Intent(this, TorchToggleActivity.class);
-        torchIntent.setAction(Intent.ACTION_VIEW);
-
-        ShortcutInfo torchShortcut = new ShortcutInfo.Builder(this, "torch_toggle")
-                .setShortLabel(getString(R.string.torch_shortcut_short_label))
-                .setLongLabel(getString(R.string.torch_shortcut_long_label))
-                .setIcon(Icon.createWithResource(this, R.drawable.flashlight_shortcut))
-                .setIntent(torchIntent)
-                .build();
-
-        // Recording Start Shortcut
-        Intent startRecordIntent = new Intent(this, RecordingStartActivity.class);
-        startRecordIntent.setAction(Intent.ACTION_VIEW);
-
-        ShortcutInfo startRecordShortcut = new ShortcutInfo.Builder(this, "record_start")
-                .setShortLabel(getString(R.string.start_recording))
-                .setLongLabel(getString(R.string.start_recording))
-                .setIcon(Icon.createWithResource(this, R.drawable.start_back_shortcut))
-                .setIntent(startRecordIntent)
-                .build();
-
-        // Recording Stop Shortcut
-        Intent stopRecordIntent = new Intent(this, RecordingStopActivity.class);
-        stopRecordIntent.setAction(Intent.ACTION_VIEW);
-
-        ShortcutInfo stopRecordShortcut = new ShortcutInfo.Builder(this, "record_stop")
-                .setShortLabel(getString(R.string.stop_recording))
-                .setLongLabel(getString(R.string.stop_recording))
-                .setIcon(Icon.createWithResource(this, R.drawable.stop_shortcut))
-                .setIntent(stopRecordIntent)
-                .build();
-
-        // Set all shortcuts
-        shortcutManager.setDynamicShortcuts(Arrays.asList(
-                torchShortcut,
-                startRecordShortcut,
-                stopRecordShortcut));
+        new ShortcutsManager(this).publishAllDynamic();
     }
 
     public void applyLanguage(String languageCode) {

--- a/app/src/main/java/com/fadcam/RecordingStartActivity.java
+++ b/app/src/main/java/com/fadcam/RecordingStartActivity.java
@@ -53,7 +53,13 @@ public class RecordingStartActivity extends Activity {
                         .apply();
             }
 
-            if (CAMERA_MODE_DUAL.equals(mode)) {
+            CameraType selectedCamera = sharedPreferencesManager.getCameraSelection();
+            boolean shouldStartDual = CAMERA_MODE_DUAL.equals(mode)
+                    || (CAMERA_MODE_CURRENT.equals(mode)
+                    && selectedCamera != null
+                    && selectedCamera.isDual());
+
+            if (shouldStartDual) {
                 Intent startDualIntent = new Intent(this, DualCameraRecordingService.class);
                 startDualIntent.setAction(Constants.INTENT_ACTION_START_DUAL_RECORDING);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/java/com/fadcam/RecordingToggleActivity.java
+++ b/app/src/main/java/com/fadcam/RecordingToggleActivity.java
@@ -45,7 +45,12 @@ public class RecordingToggleActivity extends Activity {
         } catch (Exception e) {
             FLog.e(TAG, "Error toggling recording via shortcut", e);
         } finally {
-            finish();
+            finishWithoutUi();
         }
+    }
+
+    void finishWithoutUi() {
+        moveTaskToBack(true);
+        finish();
     }
 }

--- a/app/src/main/java/com/fadcam/RecordingToggleActivity.java
+++ b/app/src/main/java/com/fadcam/RecordingToggleActivity.java
@@ -1,0 +1,64 @@
+package com.fadcam;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.SystemClock;
+
+/**
+ * No-UI entry point that routes a launcher shortcut to the existing recording
+ * start or stop activity.
+ */
+public class RecordingToggleActivity extends Activity {
+    private static final String TAG = "RecordingToggleActivity";
+    private static final RecordingToggleGuard TOGGLE_GUARD = new RecordingToggleGuard();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        try {
+            if (!TOGGLE_GUARD.tryAcquire(SystemClock.elapsedRealtime())) {
+                FLog.w(TAG, "Ignoring duplicate recording toggle request");
+                return;
+            }
+
+            SharedPreferencesManager prefs = SharedPreferencesManager.getInstance(this);
+            boolean hasActiveSession = prefs.isRecordingInProgress()
+                    || getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
+                    .getLong(Constants.PREF_RECORDING_START_TIME, 0L) > 0L;
+
+            Intent controlIntent;
+            if (hasActiveSession) {
+                FLog.i(TAG, "Routing toggle request to recording stop");
+                controlIntent = new Intent(this, RecordingStopActivity.class);
+            } else {
+                FLog.i(TAG, "Routing toggle request to recording start");
+                controlIntent = new Intent(this, RecordingStartActivity.class)
+                        .putExtra(
+                                RecordingStartActivity.EXTRA_SHORTCUT_CAMERA_MODE,
+                                RecordingStartActivity.CAMERA_MODE_CURRENT);
+            }
+            controlIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+            startActivity(controlIntent);
+        } catch (Exception e) {
+            FLog.e(TAG, "Error toggling recording via shortcut", e);
+        } finally {
+            moveTaskToBack(true);
+            finish();
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        finish();
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        moveTaskToBack(true);
+    }
+}

--- a/app/src/main/java/com/fadcam/RecordingToggleActivity.java
+++ b/app/src/main/java/com/fadcam/RecordingToggleActivity.java
@@ -45,20 +45,7 @@ public class RecordingToggleActivity extends Activity {
         } catch (Exception e) {
             FLog.e(TAG, "Error toggling recording via shortcut", e);
         } finally {
-            moveTaskToBack(true);
             finish();
         }
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        finish();
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        moveTaskToBack(true);
     }
 }

--- a/app/src/main/java/com/fadcam/RecordingToggleGuard.java
+++ b/app/src/main/java/com/fadcam/RecordingToggleGuard.java
@@ -1,0 +1,20 @@
+package com.fadcam;
+
+/**
+ * Process-local guard that suppresses duplicate recording toggle requests.
+ */
+final class RecordingToggleGuard {
+    static final long MIN_TOGGLE_INTERVAL_MS = 1000L;
+
+    private long lastAcceptedAt = Long.MIN_VALUE;
+
+    synchronized boolean tryAcquire(long elapsedRealtimeMs) {
+        if (lastAcceptedAt != Long.MIN_VALUE
+                && elapsedRealtimeMs >= lastAcceptedAt
+                && elapsedRealtimeMs - lastAcceptedAt < MIN_TOGGLE_INTERVAL_MS) {
+            return false;
+        }
+        lastAcceptedAt = elapsedRealtimeMs;
+        return true;
+    }
+}

--- a/app/src/main/java/com/fadcam/shortcuts/ShortcutsManager.java
+++ b/app/src/main/java/com/fadcam/shortcuts/ShortcutsManager.java
@@ -46,10 +46,20 @@ public class ShortcutsManager {
         @DrawableRes int defaultIcon,
         @NonNull CharSequence defaultLabel
     ) {
+        return buildShortcut(id, intent, defaultIcon, defaultLabel, defaultLabel);
+    }
+
+    public ShortcutInfoCompat buildShortcut(
+        @NonNull String id,
+        @NonNull Intent intent,
+        @DrawableRes int defaultIcon,
+        @NonNull CharSequence defaultShortLabel,
+        @NonNull CharSequence defaultLongLabel
+    ) {
         ShortcutInfoCompat.Builder b = new ShortcutInfoCompat.Builder(ctx, id);
         String customLabel = prefs.getCustomLabel(id);
-        b.setShortLabel(customLabel != null ? customLabel : defaultLabel);
-        b.setLongLabel(customLabel != null ? customLabel : defaultLabel);
+        b.setShortLabel(customLabel != null ? customLabel : defaultShortLabel);
+        b.setLongLabel(customLabel != null ? customLabel : defaultLongLabel);
         IconCompat icon = resolveIcon(id, defaultIcon);
         if (icon != null) b.setIcon(icon);
         b.setIntent(intent);
@@ -188,7 +198,8 @@ public class ShortcutsManager {
                     "com.fadcam.RecordingToggleActivity"
                 ),
                 com.fadcam.R.drawable.toggle_recording_shortcut,
-                ctx.getString(com.fadcam.R.string.shortcut_toggle_recording)
+                ctx.getString(com.fadcam.R.string.shortcut_toggle_recording),
+                ctx.getString(com.fadcam.R.string.shortcut_toggle_recording_long)
             )
         );
         // Start

--- a/app/src/main/java/com/fadcam/shortcuts/ShortcutsManager.java
+++ b/app/src/main/java/com/fadcam/shortcuts/ShortcutsManager.java
@@ -191,18 +191,6 @@ public class ShortcutsManager {
                 ctx.getString(com.fadcam.R.string.shortcut_toggle_recording)
             )
         );
-        // Torch
-        list.add(
-            buildShortcut(
-                ID_TORCH,
-                new Intent(Intent.ACTION_VIEW).setClassName(
-                    ctx,
-                    "com.fadcam.TorchToggleActivity"
-                ),
-                com.fadcam.R.drawable.flashlight_shortcut,
-                ctx.getString(com.fadcam.R.string.torch_shortcut_short_label)
-            )
-        );
         // Start
         list.add(
             buildShortcut(
@@ -216,6 +204,18 @@ public class ShortcutsManager {
                 ),
                 com.fadcam.R.drawable.start_back_shortcut,
                 ctx.getString(com.fadcam.R.string.shortcut_start_back)
+            )
+        );
+        // Stop
+        list.add(
+            buildShortcut(
+                ID_STOP,
+                new Intent(Intent.ACTION_VIEW).setClassName(
+                    ctx,
+                    "com.fadcam.RecordingStopActivity"
+                ),
+                com.fadcam.R.drawable.stop_shortcut,
+                ctx.getString(com.fadcam.R.string.stop_recording)
             )
         );
         list.add(
@@ -260,16 +260,16 @@ public class ShortcutsManager {
                 ctx.getString(com.fadcam.R.string.shortcut_start_dual)
             )
         );
-        // Stop
+        // Torch
         list.add(
             buildShortcut(
-                ID_STOP,
+                ID_TORCH,
                 new Intent(Intent.ACTION_VIEW).setClassName(
                     ctx,
-                    "com.fadcam.RecordingStopActivity"
+                    "com.fadcam.TorchToggleActivity"
                 ),
-                com.fadcam.R.drawable.stop_shortcut,
-                ctx.getString(com.fadcam.R.string.stop_recording)
+                com.fadcam.R.drawable.flashlight_shortcut,
+                ctx.getString(com.fadcam.R.string.torch_shortcut_short_label)
             )
         );
         // Photo
@@ -311,7 +311,18 @@ public class ShortcutsManager {
                 ctx.getString(com.fadcam.R.string.shortcut_take_screenshot)
             )
         );
-        ShortcutManagerCompat.setDynamicShortcuts(ctx, list);
+        List<ShortcutInfoCompat> published = list;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N_MR1) {
+            android.content.pm.ShortcutManager shortcutManager =
+                ctx.getSystemService(android.content.pm.ShortcutManager.class);
+            if (shortcutManager != null) {
+                int maxCount = shortcutManager.getMaxShortcutCountPerActivity();
+                if (maxCount > 0 && list.size() > maxCount) {
+                    published = new ArrayList<>(list.subList(0, maxCount));
+                }
+            }
+        }
+        ShortcutManagerCompat.setDynamicShortcuts(ctx, published);
     }
 
     /**

--- a/app/src/main/java/com/fadcam/shortcuts/ShortcutsManager.java
+++ b/app/src/main/java/com/fadcam/shortcuts/ShortcutsManager.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class ShortcutsManager {
 
     public static final String ID_TORCH = "torch_toggle";
+    public static final String ID_TOGGLE = "record_toggle";
     public static final String ID_START = "record_start";
     public static final String ID_START_FRONT = "record_start_front";
     public static final String ID_START_CURRENT = "record_start_current";
@@ -178,6 +179,18 @@ public class ShortcutsManager {
      */
     public void publishAllDynamic() {
         List<ShortcutInfoCompat> list = new ArrayList<>();
+        // Toggle recording
+        list.add(
+            buildShortcut(
+                ID_TOGGLE,
+                new Intent(Intent.ACTION_VIEW).setClassName(
+                    ctx,
+                    "com.fadcam.RecordingToggleActivity"
+                ),
+                com.fadcam.R.drawable.toggle_recording_shortcut,
+                ctx.getString(com.fadcam.R.string.shortcut_toggle_recording)
+            )
+        );
         // Torch
         list.add(
             buildShortcut(
@@ -321,6 +334,20 @@ public class ShortcutsManager {
             // shortcuts but tries to update their metadata where supported.
             if (isPinSupported()) {
                 List<ShortcutInfoCompat> pinned = new ArrayList<>();
+
+                pinned.add(
+                    buildShortcutForPin(
+                        ID_TOGGLE,
+                        new Intent(Intent.ACTION_VIEW).setClassName(
+                            ctx,
+                            "com.fadcam.RecordingToggleActivity"
+                        ),
+                        com.fadcam.R.drawable.toggle_recording_shortcut,
+                        ctx.getString(
+                            com.fadcam.R.string.shortcut_toggle_recording
+                        )
+                    )
+                );
 
                 pinned.add(
                     buildShortcutForPin(

--- a/app/src/main/res/drawable/toggle_recording_shortcut.xml
+++ b/app/src/main/res/drawable/toggle_recording_shortcut.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#141414"
+        android:pathData="M0,0H24V24H0Z" />
+    <path
+        android:fillColor="#2ECC71"
+        android:pathData="M19,8L15,12H18C18,15.31 15.31,18 12,18C10.99,18 10.03,17.75 9.2,17.3L7.74,18.76C8.97,19.54 10.43,20 12,20C16.42,20 20,16.42 20,12H23L19,8ZM6,12C6,8.69 8.69,6 12,6C13.01,6 13.97,6.25 14.8,6.7L16.26,5.24C15.03,4.46 13.57,4 12,4C7.58,4 4,7.58 4,12H1L5,16L9,12H6Z" />
+    <path
+        android:fillColor="#E74C3C"
+        android:pathData="M10,10H14V14H10Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -980,6 +980,8 @@
     <string name="shortcut_start_front">Start Front</string>
     <string name="shortcut_start_current">Start Current</string>
     <string name="shortcut_start_dual">Start Dual</string>
+    <string name="shortcut_toggle_recording">Toggle Recording</string>
+    <string name="shortcut_toggle_recording_long">Start or stop recording</string>
     <string name="stop_recording">Stop</string>
     <string name="shortcut_take_photo">Photo</string>
     <string name="shortcut_take_photo_front">Selfie</string>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
+        android:id="@+id/record_toggle"
+        android:enabled="true"
+        android:icon="@drawable/toggle_recording_shortcut"
+        android:shortcutShortLabel="@string/shortcut_toggle_recording"
+        android:shortcutLongLabel="@string/shortcut_toggle_recording_long">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetClass="com.fadcam.RecordingToggleActivity"
+            android:targetPackage="com.fadcam" />
+    </shortcut>
+
+    <shortcut
         android:id="@+id/torch_toggle"
         android:enabled="true"
         android:icon="@drawable/flashlight_shortcut"

--- a/app/src/test/java/com/fadcam/RecordingToggleActivityTest.java
+++ b/app/src/test/java/com/fadcam/RecordingToggleActivityTest.java
@@ -1,0 +1,22 @@
+package com.fadcam;
+
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+
+public class RecordingToggleActivityTest {
+    @Test
+    public void finishWithoutUiBackgroundsTaskBeforeFinishing() {
+        RecordingToggleActivity activity = mock(RecordingToggleActivity.class);
+        doCallRealMethod().when(activity).finishWithoutUi();
+
+        activity.finishWithoutUi();
+
+        InOrder completionOrder = inOrder(activity);
+        completionOrder.verify(activity).moveTaskToBack(true);
+        completionOrder.verify(activity).finish();
+    }
+}

--- a/app/src/test/java/com/fadcam/RecordingToggleGuardTest.java
+++ b/app/src/test/java/com/fadcam/RecordingToggleGuardTest.java
@@ -1,0 +1,34 @@
+package com.fadcam;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RecordingToggleGuardTest {
+
+    @Test
+    public void rejectsInvocationInsideGuardWindow() {
+        RecordingToggleGuard guard = new RecordingToggleGuard();
+
+        assertTrue(guard.tryAcquire(10_000L));
+        assertFalse(guard.tryAcquire(10_999L));
+    }
+
+    @Test
+    public void acceptsInvocationAtGuardWindowBoundary() {
+        RecordingToggleGuard guard = new RecordingToggleGuard();
+
+        assertTrue(guard.tryAcquire(10_000L));
+        assertTrue(guard.tryAcquire(
+                10_000L + RecordingToggleGuard.MIN_TOGGLE_INTERVAL_MS));
+    }
+
+    @Test
+    public void acceptsInvocationAfterElapsedRealtimeReset() {
+        RecordingToggleGuard guard = new RecordingToggleGuard();
+
+        assertTrue(guard.tryAcquire(10_000L));
+        assertTrue(guard.tryAcquire(100L));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a state-aware **Toggle Recording** launcher shortcut. It starts the currently configured normal or dual-camera mode when idle and delegates to the existing stop pathway when a recording session is active.

This PR implements the existing Recording Toggle Action feature request in #320.

## Motivation

A single toggle is more convenient than separate Start and Stop entries for launchers, accessibility workflows, hardware-button actions, and external automation while preserving the existing dedicated shortcuts.

## Implementation

- Adds a translucent, no-history `RecordingToggleActivity` that only resolves state and delegates to the existing start/stop activities.
- Uses the existing recording preference plus the service-owned recording timeline so paused sessions are still treated as active.
- Adds a one-second elapsed-realtime guard against duplicate transitions.
- Extends the current-camera start route to honor an already-selected dual-camera mode.
- Registers the static and dynamic shortcut with a project-style icon, accessible short/long labels, and rank 0.
- Centralizes dynamic shortcut publication in `ShortcutsManager`; existing Start, Stop, camera, photo, torch, and FadRec entries remain published.

The shortcut controller follows the existing exported start/stop activity security model. Recording services remain non-exported, and no recording implementation is duplicated.

## User-visible changes

Launcher implementations and automation interfaces that support Android deep shortcuts show **Toggle Recording** first, with the description **Start or stop recording**.

Existing separate Start and Stop shortcuts remain available.

## Testing

### Automated and emulator testing

- [x] `./gradlew assembleDefaultDebug testDefaultDebugUnitTest` — passed.
- [x] `./gradlew connectedDefaultDebugAndroidTest` — completed successfully on BlueStacks.
- [x] Guard unit tests cover a repeat inside 1 second, the exact boundary, and elapsed-realtime reset.
- [x] Installed `app/build/outputs/apk/default/debug/app-default-arm64-v8a-debug.apk` with `adb install -r -t`.
- [x] Android shortcut service reports all 10 dynamic shortcuts; `record_toggle` is rank 0 and Start/Stop are ranks 1/2.
- [x] A second shell invocation after 200 ms was coalesced into the existing no-UI activity and did not dispatch a second transition or crash.
- [x] Logcat checked for `AndroidRuntime` fatal exceptions during shortcut invocation; none occurred.
- [ ] `./gradlew lintDefaultDebug` — ran but fails on the pre-existing repository baseline: 823 errors and 3600 warnings. The first error is unchanged at `RecordingService.java:6821 [MissingPermission]`; this change adds no lint errors or suppressions.

BlueStacks environment: BlueStacks 5.22.167.1006, Android 13 / API 33, reported model SM-G998B, package `com.fadcam.beta`.

### Real-device testing

Manually tested on a Samsung Galaxy S26 Ultra running Android 16.

- [x] **Toggle Recording** appears correctly in Samsung’s shortcut/action picker.
- [x] Invoking it while idle starts recording.
- [x] Invoking it again while recording stops the active recording.
- [x] The stopped recording is finalized and saved correctly.
- [x] Repeated start and stop cycles work.
- [x] The currently configured camera mode is respected.
- [x] Existing separate Start and Stop actions remain available.
- [x] The action does not leave the FadCam interface open unnecessarily.
- [x] No crashes or functional issues were observed during real-device testing.

Full sanitized automated command/log evidence remains available here:

[Manual validation evidence](https://raw.githubusercontent.com/i7xre/FadCam/pr-evidence-toggle/pr-evidence/recording-toggle/manual-validation.md)

## Screenshot

The screenshot below was captured on a Samsung Galaxy S26 Ultra and shows the new **Toggle Recording** action alongside FadCam’s existing actions.

![Toggle Recording on Samsung Galaxy S26 Ultra](https://raw.githubusercontent.com/i7xre/FadCam/pr-evidence-toggle/pr-evidence/recording-toggle/03-toggle-recording-samsung-galaxy-s26-ultra.png)

## Risks and edge cases

- The debounce window and Android activity coalescing prevent rapid taps from issuing conflicting transitions.
- Paused recordings remain active because the service-owned elapsed timeline is checked in addition to the boolean preference.
- Current mode resolves dual-camera selection through the existing dual service when supported.
- The controller contains no camera or file-finalization logic; stopping continues through the existing service pathway.
- Existing dedicated Start and Stop actions remain unchanged.

## Related issue

Closes #320