### PR TITLE
feat: bookmark important timestamps during recording

### DIFF
--- a/app/src/main/java/com/fadcam/Constants.java
+++ b/app/src/main/java/com/fadcam/Constants.java
@@ -424,7 +424,7 @@ public abstract class Constants {
     // Quick-action button slots (comma-separated "token:slot" pairs). Key bumped to
     // v2 so polluted positions saved by earlier broken drag builds are discarded.
     public static final String PREF_QUICK_ACTIONS_ORDER = "pref_quick_actions_slots_v2";
-    public static final String DEFAULT_QUICK_ACTIONS_ORDER = "timer,mute,full,fadshot";
+    public static final String DEFAULT_QUICK_ACTIONS_ORDER = "timer,mute,full,fadshot,bookmark";
     // Sidebar mini apps: pipe-separated order of ALL mini app ids (user-reorderable)
     // + how many of the top of that order are shown in the home sidebar (default 3).
     // Count key bumped to v2 so early test builds' stored values are discarded.
@@ -515,6 +515,24 @@ public abstract class Constants {
         "com.fadcam.TOGGLE_RECORDING_TORCH";
     public static final String INTENT_ACTION_CAPTURE_PHOTO =
         "com.fadcam.CAPTURE_PHOTO";
+
+    // -------------- Recording bookmarks Start --------------
+    /**
+     * Asks the recording service to bookmark the moment the user is currently
+     * recording. Handled only while a recording is running or paused.
+     */
+    public static final String INTENT_ACTION_ADD_BOOKMARK =
+        "com.fadcam.ADD_BOOKMARK";
+    /** Sent back once a bookmark has been stored for the active segment. */
+    public static final String BROADCAST_ON_BOOKMARK_ADDED =
+        "ON_BOOKMARK_ADDED";
+    /** Extra (long): the bookmarked offset inside the active segment, in ms. */
+    public static final String EXTRA_BOOKMARK_POSITION_MS =
+        "com.fadcam.EXTRA_BOOKMARK_POSITION_MS";
+    /** Extra (int): how many bookmarks the active segment now has. */
+    public static final String EXTRA_BOOKMARK_COUNT =
+        "com.fadcam.EXTRA_BOOKMARK_COUNT";
+    // -------------- Recording bookmarks End --------------
     // Broadcast action sent by RecordingService when video processing is done
     public static final String ACTION_RECORDING_COMPLETE =
         "com.fadcam.RECORDING_COMPLETE";

--- a/app/src/main/java/com/fadcam/bookmarks/Bookmark.java
+++ b/app/src/main/java/com/fadcam/bookmarks/Bookmark.java
@@ -1,0 +1,92 @@
+package com.fadcam.bookmarks;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * A single user-marked moment inside a recording.
+ *
+ * <p>Immutable value object. {@link #positionMs} is the offset from the start of
+ * the media file the bookmark belongs to, so it can be handed straight to the
+ * player as a seek target.</p>
+ */
+public final class Bookmark implements Comparable<Bookmark> {
+
+    private static final String KEY_POSITION_MS = "position_ms";
+    private static final String KEY_CREATED_AT = "created_at";
+
+    private final long positionMs;
+    private final long createdAtEpochMs;
+
+    /**
+     * @param positionMs       offset inside the media file, in milliseconds (clamped to &gt;= 0)
+     * @param createdAtEpochMs wall-clock time the bookmark was created, in epoch milliseconds
+     */
+    public Bookmark(long positionMs, long createdAtEpochMs) {
+        this.positionMs = Math.max(0L, positionMs);
+        this.createdAtEpochMs = createdAtEpochMs;
+    }
+
+    /** @return offset inside the media file, in milliseconds. */
+    public long getPositionMs() {
+        return positionMs;
+    }
+
+    /** @return wall-clock creation time, in epoch milliseconds. */
+    public long getCreatedAtEpochMs() {
+        return createdAtEpochMs;
+    }
+
+    /**
+     * Serialises this bookmark.
+     *
+     * @return a JSON object holding the position and creation time
+     * @throws JSONException if the values cannot be written
+     */
+    @NonNull
+    public JSONObject toJson() throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put(KEY_POSITION_MS, positionMs);
+        json.put(KEY_CREATED_AT, createdAtEpochMs);
+        return json;
+    }
+
+    /**
+     * Deserialises a bookmark previously written by {@link #toJson()}.
+     *
+     * @param json the stored object
+     * @return the restored bookmark
+     */
+    @NonNull
+    public static Bookmark fromJson(@NonNull JSONObject json) {
+        return new Bookmark(
+                json.optLong(KEY_POSITION_MS, 0L),
+                json.optLong(KEY_CREATED_AT, 0L));
+    }
+
+    /** Orders bookmarks by their position in the media file. */
+    @Override
+    public int compareTo(@NonNull Bookmark other) {
+        return Long.compare(positionMs, other.positionMs);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (!(other instanceof Bookmark)) return false;
+        return positionMs == ((Bookmark) other).positionMs;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(positionMs);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "Bookmark{positionMs=" + positionMs + "}";
+    }
+}

--- a/app/src/main/java/com/fadcam/bookmarks/BookmarkRepository.java
+++ b/app/src/main/java/com/fadcam/bookmarks/BookmarkRepository.java
@@ -1,0 +1,260 @@
+package com.fadcam.bookmarks;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.OpenableColumns;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.fadcam.FLog;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Persistence for recording bookmarks — the moments a user marked while recording.
+ *
+ * <p>Bookmarks are stored in their own {@link SharedPreferences} file, one JSON
+ * array per media file, keyed by the media's <em>display name</em> rather than
+ * its URI: SAF document URIs change whenever a file is renamed, moved to the
+ * trash or restored, while the display name survives all three.</p>
+ *
+ * <p>All mutating calls are synchronised and committed synchronously, because the
+ * writer ({@link com.fadcam.services.RecordingService}) and the readers (player /
+ * records UI) live in different components and must never observe a half-written
+ * list.</p>
+ */
+public final class BookmarkRepository {
+
+    private static final String TAG = "BookmarkRepository";
+
+    /** Dedicated prefs file so bookmarks never collide with app settings. */
+    private static final String PREFS_NAME = "fadcam_bookmarks";
+
+    /** Prefix for the per-media entries inside {@link #PREFS_NAME}. */
+    private static final String KEY_PREFIX = "bookmarks_";
+
+    /**
+     * Two bookmarks closer together than this are treated as the same moment.
+     * Guards against a double tap producing a duplicate marker.
+     */
+    private static final long MIN_SPACING_MS = 400L;
+
+    private static volatile BookmarkRepository instance;
+
+    private final SharedPreferences preferences;
+
+    private BookmarkRepository(@NonNull Context context) {
+        this.preferences = context.getApplicationContext()
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    /**
+     * Thread-safe singleton accessor.
+     *
+     * @param context any context; the application context is retained
+     * @return the shared repository instance
+     */
+    @NonNull
+    public static BookmarkRepository getInstance(@NonNull Context context) {
+        if (instance == null) {
+            synchronized (BookmarkRepository.class) {
+                if (instance == null) {
+                    instance = new BookmarkRepository(context);
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Resolves the storage key for a media URI: its display name for SAF content
+     * URIs, the last path segment otherwise.
+     *
+     * <p>Both the recording side and the playback side must derive the key the
+     * same way, so this is the single place that does it.</p>
+     *
+     * @param context context used to query the content resolver
+     * @param uri     media URI; may be {@code null}
+     * @return the media name, or {@code null} when it cannot be resolved
+     */
+    @Nullable
+    public static String resolveMediaName(@NonNull Context context, @Nullable Uri uri) {
+        if (uri == null) {
+            return null;
+        }
+        if ("content".equals(uri.getScheme())) {
+            try (Cursor cursor = context.getContentResolver()
+                    .query(uri, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null)) {
+                if (cursor != null && cursor.moveToFirst()) {
+                    int column = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                    if (column >= 0 && !cursor.isNull(column)) {
+                        String name = cursor.getString(column);
+                        if (name != null && !name.isEmpty()) {
+                            return name;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                FLog.w(TAG, "Could not query display name for " + uri + ": " + e.getMessage());
+            }
+        }
+        String path = uri.getPath();
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+        int cut = path.lastIndexOf('/');
+        String name = cut >= 0 ? path.substring(cut + 1) : path;
+        return name.isEmpty() ? null : name;
+    }
+
+    /**
+     * Adds a bookmark for a media file, ignoring positions that duplicate an
+     * existing marker (see {@link #MIN_SPACING_MS}).
+     *
+     * @param mediaName  the media's display name
+     * @param positionMs offset inside the media file, in milliseconds
+     * @return the number of bookmarks the media has after the call
+     */
+    public synchronized int add(@Nullable String mediaName, long positionMs) {
+        if (mediaName == null || mediaName.isEmpty()) {
+            FLog.w(TAG, "add: ignored — no media name");
+            return 0;
+        }
+        List<Bookmark> bookmarks = getAll(mediaName);
+        long clamped = Math.max(0L, positionMs);
+        for (Bookmark existing : bookmarks) {
+            if (Math.abs(existing.getPositionMs() - clamped) < MIN_SPACING_MS) {
+                FLog.d(TAG, "add: duplicate at " + clamped + "ms ignored for " + mediaName);
+                return bookmarks.size();
+            }
+        }
+        bookmarks.add(new Bookmark(clamped, System.currentTimeMillis()));
+        Collections.sort(bookmarks);
+        write(mediaName, bookmarks);
+        FLog.i(TAG, "Bookmark added at " + clamped + "ms for " + mediaName
+                + " (total " + bookmarks.size() + ")");
+        return bookmarks.size();
+    }
+
+    /**
+     * Reads every bookmark stored for a media file.
+     *
+     * @param mediaName the media's display name
+     * @return a modifiable list ordered by position; empty when nothing is stored
+     */
+    @NonNull
+    public List<Bookmark> getAll(@Nullable String mediaName) {
+        List<Bookmark> bookmarks = new ArrayList<>();
+        if (mediaName == null || mediaName.isEmpty()) {
+            return bookmarks;
+        }
+        String stored = preferences.getString(KEY_PREFIX + mediaName, null);
+        if (stored == null || stored.isEmpty()) {
+            return bookmarks;
+        }
+        try {
+            JSONArray array = new JSONArray(stored);
+            for (int i = 0; i < array.length(); i++) {
+                JSONObject item = array.optJSONObject(i);
+                if (item != null) {
+                    bookmarks.add(Bookmark.fromJson(item));
+                }
+            }
+            Collections.sort(bookmarks);
+        } catch (Exception e) {
+            FLog.w(TAG, "Corrupt bookmark data for " + mediaName + ", dropping it: " + e.getMessage());
+            preferences.edit().remove(KEY_PREFIX + mediaName).apply();
+            bookmarks.clear();
+        }
+        return bookmarks;
+    }
+
+    /**
+     * @param mediaName the media's display name
+     * @return how many bookmarks the media has
+     */
+    public int count(@Nullable String mediaName) {
+        return getAll(mediaName).size();
+    }
+
+    /**
+     * Removes a single bookmark.
+     *
+     * @param mediaName  the media's display name
+     * @param positionMs the exact position of the bookmark to drop
+     * @return {@code true} when a bookmark was removed
+     */
+    public synchronized boolean remove(@Nullable String mediaName, long positionMs) {
+        if (mediaName == null || mediaName.isEmpty()) {
+            return false;
+        }
+        List<Bookmark> bookmarks = getAll(mediaName);
+        boolean removed = bookmarks.remove(new Bookmark(positionMs, 0L));
+        if (removed) {
+            write(mediaName, bookmarks);
+        }
+        return removed;
+    }
+
+    /**
+     * Drops every bookmark stored for a media file.
+     *
+     * @param mediaName the media's display name
+     */
+    public synchronized void clear(@Nullable String mediaName) {
+        if (mediaName == null || mediaName.isEmpty()) {
+            return;
+        }
+        preferences.edit().remove(KEY_PREFIX + mediaName).commit();
+    }
+
+    /**
+     * Re-keys a media file's bookmarks after a rename so they stay attached to
+     * the file the user still thinks of as the same recording.
+     *
+     * @param oldMediaName the previous display name
+     * @param newMediaName the new display name
+     */
+    public synchronized void move(@Nullable String oldMediaName, @Nullable String newMediaName) {
+        if (oldMediaName == null || newMediaName == null
+                || oldMediaName.isEmpty() || newMediaName.isEmpty()
+                || oldMediaName.equals(newMediaName)) {
+            return;
+        }
+        String stored = preferences.getString(KEY_PREFIX + oldMediaName, null);
+        if (stored == null) {
+            return;
+        }
+        preferences.edit()
+                .remove(KEY_PREFIX + oldMediaName)
+                .putString(KEY_PREFIX + newMediaName, stored)
+                .commit();
+        FLog.d(TAG, "Bookmarks moved from " + oldMediaName + " to " + newMediaName);
+    }
+
+    /** Serialises and commits a bookmark list, removing the entry when empty. */
+    private void write(@NonNull String mediaName, @NonNull List<Bookmark> bookmarks) {
+        String key = KEY_PREFIX + mediaName;
+        if (bookmarks.isEmpty()) {
+            preferences.edit().remove(key).commit();
+            return;
+        }
+        try {
+            JSONArray array = new JSONArray();
+            for (Bookmark bookmark : bookmarks) {
+                array.put(bookmark.toJson());
+            }
+            preferences.edit().putString(key, array.toString()).commit();
+        } catch (Exception e) {
+            FLog.e(TAG, "Failed to persist bookmarks for " + mediaName, e);
+        }
+    }
+}

--- a/app/src/main/java/com/fadcam/bookmarks/BookmarkRepository.java
+++ b/app/src/main/java/com/fadcam/bookmarks/BookmarkRepository.java
@@ -147,11 +147,14 @@ public final class BookmarkRepository {
     /**
      * Reads every bookmark stored for a media file.
      *
+     * <p>Unreadable data is dropped in place, so this read can mutate the store —
+     * hence the lock and the synchronous commit shared with the write path.</p>
+     *
      * @param mediaName the media's display name
      * @return a modifiable list ordered by position; empty when nothing is stored
      */
     @NonNull
-    public List<Bookmark> getAll(@Nullable String mediaName) {
+    public synchronized List<Bookmark> getAll(@Nullable String mediaName) {
         List<Bookmark> bookmarks = new ArrayList<>();
         if (mediaName == null || mediaName.isEmpty()) {
             return bookmarks;
@@ -171,7 +174,7 @@ public final class BookmarkRepository {
             Collections.sort(bookmarks);
         } catch (Exception e) {
             FLog.w(TAG, "Corrupt bookmark data for " + mediaName + ", dropping it: " + e.getMessage());
-            preferences.edit().remove(KEY_PREFIX + mediaName).apply();
+            preferences.edit().remove(KEY_PREFIX + mediaName).commit();
             bookmarks.clear();
         }
         return bookmarks;

--- a/app/src/main/java/com/fadcam/bookmarks/ui/BookmarkMarkersView.java
+++ b/app/src/main/java/com/fadcam/bookmarks/ui/BookmarkMarkersView.java
@@ -1,0 +1,131 @@
+package com.fadcam.bookmarks.ui;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.fadcam.bookmarks.Bookmark;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Draws bookmark markers on top of the player's time slider.
+ *
+ * <p>The view is laid out over the slider and mirrors its track geometry, so a
+ * marker sits exactly above the position it refers to. It never handles touches:
+ * scrubbing must keep working through it, so it stays non-clickable and lets
+ * every event fall through to the slider underneath.</p>
+ */
+public class BookmarkMarkersView extends View {
+
+    /** Marker colour — the amber used for quick-action value badges. */
+    private static final int COLOR_MARKER = 0xFFFFD54F;
+
+    private static final float MARKER_WIDTH_DP = 2f;
+    private static final float MARKER_DOT_RADIUS_DP = 3f;
+
+    private final Paint markerPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final List<Bookmark> bookmarks = new ArrayList<>();
+
+    private float markerWidthPx;
+    private float dotRadiusPx;
+
+    private long durationMs = 0L;
+    private int trackStartPx = 0;
+    private int trackWidthPx = 0;
+
+    public BookmarkMarkersView(Context context) {
+        super(context);
+        init();
+    }
+
+    public BookmarkMarkersView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    private void init() {
+        float density = getResources().getDisplayMetrics().density;
+        markerWidthPx = MARKER_WIDTH_DP * density;
+        dotRadiusPx = MARKER_DOT_RADIUS_DP * density;
+        markerPaint.setColor(COLOR_MARKER);
+        markerPaint.setStyle(Paint.Style.FILL);
+        setClickable(false);
+        setFocusable(false);
+    }
+
+    /**
+     * Replaces the markers shown.
+     *
+     * @param bookmarks the bookmarks to draw; {@code null} clears the view
+     */
+    public void setBookmarks(@Nullable List<Bookmark> bookmarks) {
+        this.bookmarks.clear();
+        if (bookmarks != null) {
+            this.bookmarks.addAll(bookmarks);
+        }
+        invalidate();
+    }
+
+    /**
+     * Sets the media duration the marker positions are mapped against.
+     *
+     * @param durationMs total media duration in milliseconds
+     */
+    public void setDurationMs(long durationMs) {
+        if (this.durationMs == durationMs) {
+            return;
+        }
+        this.durationMs = durationMs;
+        invalidate();
+    }
+
+    /**
+     * Mirrors the slider's track geometry so markers line up with the thumb.
+     *
+     * @param trackStartPx x offset of the track inside this view, in pixels
+     * @param trackWidthPx drawn track width, in pixels
+     */
+    public void setTrackGeometry(int trackStartPx, int trackWidthPx) {
+        if (this.trackStartPx == trackStartPx && this.trackWidthPx == trackWidthPx) {
+            return;
+        }
+        this.trackStartPx = trackStartPx;
+        this.trackWidthPx = trackWidthPx;
+        invalidate();
+    }
+
+    /** @return {@code true} when there is at least one marker to draw. */
+    public boolean hasBookmarks() {
+        return !bookmarks.isEmpty();
+    }
+
+    @Override
+    protected void onDraw(@NonNull Canvas canvas) {
+        super.onDraw(canvas);
+        if (bookmarks.isEmpty() || durationMs <= 0L || trackWidthPx <= 0) {
+            return;
+        }
+        int height = getHeight();
+        if (height <= 0) {
+            return;
+        }
+        for (Bookmark bookmark : bookmarks) {
+            float fraction = Math.min(1f, Math.max(0f, bookmark.getPositionMs() / (float) durationMs));
+            float centerX = trackStartPx + fraction * trackWidthPx;
+            canvas.drawCircle(centerX, dotRadiusPx, dotRadiusPx, markerPaint);
+            canvas.drawRect(
+                    centerX - markerWidthPx / 2f,
+                    dotRadiusPx,
+                    centerX + markerWidthPx / 2f,
+                    height,
+                    markerPaint);
+        }
+    }
+}

--- a/app/src/main/java/com/fadcam/bookmarks/ui/BookmarksBottomSheet.java
+++ b/app/src/main/java/com/fadcam/bookmarks/ui/BookmarksBottomSheet.java
@@ -1,0 +1,146 @@
+package com.fadcam.bookmarks.ui;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.fadcam.R;
+import com.fadcam.bookmarks.Bookmark;
+import com.fadcam.bookmarks.BookmarkRepository;
+import com.fadcam.ui.faditor.util.TimeFormatter;
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+
+import java.util.List;
+
+/**
+ * Lists the bookmarks of the video being played so the user can jump straight to
+ * a marked moment, drop a single mark, or clear them all.
+ *
+ * <p>The host supplies the seek behaviour through {@link Listener}; the sheet owns
+ * the storage side and reports back whenever the set of bookmarks changed so the
+ * timeline markers can be redrawn.</p>
+ */
+public class BookmarksBottomSheet extends BottomSheetDialogFragment {
+
+    private static final String ARG_MEDIA_NAME = "media_name";
+
+    /** Callbacks the hosting player must provide. */
+    public interface Listener {
+        /**
+         * Seeks the player to a bookmarked moment.
+         *
+         * @param positionMs the bookmark position, in milliseconds
+         */
+        void onBookmarkSelected(long positionMs);
+
+        /** Called after any change to the stored bookmarks. */
+        void onBookmarksChanged();
+    }
+
+    private String mediaName;
+    private BookmarkRepository repository;
+    private LinearLayout container;
+    private TextView emptyText;
+    private TextView clearAllButton;
+
+    /**
+     * @param mediaName display name of the video whose bookmarks are shown
+     * @return a configured sheet instance
+     */
+    @NonNull
+    public static BookmarksBottomSheet newInstance(@NonNull String mediaName) {
+        BookmarksBottomSheet sheet = new BookmarksBottomSheet();
+        Bundle args = new Bundle();
+        args.putString(ARG_MEDIA_NAME, mediaName);
+        sheet.setArguments(args);
+        return sheet;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mediaName = getArguments() != null ? getArguments().getString(ARG_MEDIA_NAME) : null;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.bottom_sheet_bookmarks, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        repository = BookmarkRepository.getInstance(requireContext());
+        container = view.findViewById(R.id.bookmarks_container);
+        emptyText = view.findViewById(R.id.bookmarks_empty_text);
+        clearAllButton = view.findViewById(R.id.bookmarks_clear_all);
+        clearAllButton.setOnClickListener(v -> {
+            repository.clear(mediaName);
+            notifyChanged();
+            dismiss();
+        });
+        renderBookmarks();
+    }
+
+    /** Rebuilds the list from storage. */
+    private void renderBookmarks() {
+        container.removeAllViews();
+        List<Bookmark> bookmarks = repository.getAll(mediaName);
+        boolean empty = bookmarks.isEmpty();
+        emptyText.setVisibility(empty ? View.VISIBLE : View.GONE);
+        clearAllButton.setVisibility(empty ? View.GONE : View.VISIBLE);
+
+        LayoutInflater inflater = LayoutInflater.from(requireContext());
+        for (int index = 0; index < bookmarks.size(); index++) {
+            final Bookmark bookmark = bookmarks.get(index);
+            View row = inflater.inflate(R.layout.item_bookmark_row, container, false);
+            TextView position = row.findViewById(R.id.bookmark_position);
+            TextView label = row.findViewById(R.id.bookmark_label);
+            TextView delete = row.findViewById(R.id.bookmark_delete);
+
+            position.setText(TimeFormatter.formatAuto(bookmark.getPositionMs()));
+            label.setText(getString(R.string.bookmarks_item_label, index + 1));
+
+            row.setOnClickListener(v -> {
+                Listener listener = resolveListener();
+                if (listener != null) {
+                    listener.onBookmarkSelected(bookmark.getPositionMs());
+                }
+                dismiss();
+            });
+            delete.setOnClickListener(v -> {
+                repository.remove(mediaName, bookmark.getPositionMs());
+                notifyChanged();
+                renderBookmarks();
+            });
+
+            LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT);
+            params.bottomMargin = Math.round(8 * getResources().getDisplayMetrics().density);
+            container.addView(row, params);
+        }
+    }
+
+    /** Tells the host that stored bookmarks changed. */
+    private void notifyChanged() {
+        Listener listener = resolveListener();
+        if (listener != null) {
+            listener.onBookmarksChanged();
+        }
+    }
+
+    /** @return the hosting activity as a {@link Listener}, or {@code null}. */
+    @Nullable
+    private Listener resolveListener() {
+        return getActivity() instanceof Listener ? (Listener) getActivity() : null;
+    }
+}

--- a/app/src/main/java/com/fadcam/dualcam/service/DualCameraRecordingService.java
+++ b/app/src/main/java/com/fadcam/dualcam/service/DualCameraRecordingService.java
@@ -70,6 +70,7 @@ import java.util.Collections;
  *   <li>{@link Constants#INTENT_ACTION_RESUME_DUAL_RECORDING}</li>
  *   <li>{@link Constants#INTENT_ACTION_SWAP_DUAL_CAMERAS}</li>
  *   <li>{@link Constants#INTENT_ACTION_UPDATE_PIP_CONFIG}</li>
+ *   <li>{@link Constants#INTENT_ACTION_ADD_BOOKMARK}</li>
  * </ul>
  *
  * <h3>Broadcasts</h3>
@@ -259,6 +260,10 @@ public class DualCameraRecordingService extends Service {
 
             case Constants.INTENT_ACTION_CAPTURE_PHOTO:
                 handleCapturePhoto();
+                break;
+
+            case Constants.INTENT_ACTION_ADD_BOOKMARK:
+                addBookmarkAtCurrentPosition();
                 break;
 
             default:
@@ -1761,6 +1766,60 @@ public class DualCameraRecordingService extends Service {
             .remove(Constants.PREF_RECORDING_ACCUMULATED_PAUSED_DURATION)
             .apply();
         FLog.d(TAG, "Cleared dual recording timeline state");
+    }
+
+    // ── Bookmarks ─────────────────────────────────────────────────────
+
+    /** Milliseconds recorded so far, with paused stretches taken out. */
+    private long getEffectiveTimelineMs() {
+        if (recordingStartTime <= 0L) {
+            return 0L;
+        }
+        long anchor = (state == DualCameraState.PAUSED && pauseStartedAt > 0L)
+                ? pauseStartedAt
+                : SystemClock.elapsedRealtime();
+        return Math.max(0L, anchor - recordingStartTime - accumulatedPausedDurationMs);
+    }
+
+    /**
+     * Stores a bookmark for the moment currently being recorded.
+     *
+     * <p>Dual recording never splits into segments, so the session timeline is
+     * already the offset inside the output file. Ignored when nothing is being
+     * recorded, because there would be no file to attach the mark to.</p>
+     */
+    private void addBookmarkAtCurrentPosition() {
+        if (state != DualCameraState.RECORDING && state != DualCameraState.PAUSED) {
+            FLog.w(TAG, "addBookmarkAtCurrentPosition: ignored — no active dual recording");
+            return;
+        }
+        if (lastRecordingUriString == null || lastRecordingUriString.isEmpty()) {
+            FLog.w(TAG, "addBookmarkAtCurrentPosition: ignored — no output file yet");
+            return;
+        }
+        try {
+            String mediaName = com.fadcam.bookmarks.BookmarkRepository
+                    .resolveMediaName(this, Uri.parse(lastRecordingUriString));
+            if (mediaName == null) {
+                FLog.w(TAG, "addBookmarkAtCurrentPosition: could not resolve a name for "
+                        + lastRecordingUriString);
+                return;
+            }
+            long positionMs = getEffectiveTimelineMs();
+            int total = com.fadcam.bookmarks.BookmarkRepository.getInstance(this)
+                    .add(mediaName, positionMs);
+            broadcastOnBookmarkAdded(positionMs, total);
+        } catch (Exception e) {
+            FLog.e(TAG, "Failed to add bookmark for " + lastRecordingUriString, e);
+        }
+    }
+
+    /** Tells the UI that a bookmark landed, so it can confirm it to the user. */
+    private void broadcastOnBookmarkAdded(long positionMs, int total) {
+        Intent intent = new Intent(Constants.BROADCAST_ON_BOOKMARK_ADDED);
+        intent.putExtra(Constants.EXTRA_BOOKMARK_POSITION_MS, positionMs);
+        intent.putExtra(Constants.EXTRA_BOOKMARK_COUNT, total);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
     }
 
     // ── Broadcasting ──────────────────────────────────────────────────

--- a/app/src/main/java/com/fadcam/services/RecordingService.java
+++ b/app/src/main/java/com/fadcam/services/RecordingService.java
@@ -166,6 +166,14 @@ public class RecordingService extends Service {
     private long pauseStartedAt;
     private long accumulatedPausedDurationMs;
 
+    /**
+     * Session timeline offset (see {@link #getEffectiveTimelineMs()}) at which the
+     * segment currently being written started. Split recordings produce one file
+     * per segment, so bookmarks must be stored relative to this offset to line up
+     * with the playback position inside that file.
+     */
+    private volatile long currentSegmentStartTimelineMs;
+
     private SharedPreferencesManager sharedPreferencesManager; // Your settings manager
 
     private boolean isRolloverClosingOldSession = false; // Flag to manage state during segment rollover when the old
@@ -1960,6 +1968,9 @@ public class RecordingService extends Service {
         } else if (Constants.INTENT_ACTION_CAPTURE_PHOTO.equals(action)) {
             capturePhotoFromRecording();
             return START_STICKY;
+        } else if (Constants.INTENT_ACTION_ADD_BOOKMARK.equals(action)) {
+            addBookmarkAtCurrentPosition();
+            return START_STICKY;
         }
 
         else if (Constants.INTENT_ACTION_REINITIALIZE_LOCATION.equals(action)) {
@@ -2354,6 +2365,7 @@ public class RecordingService extends Service {
         recordingStartTime = 0L;
         pauseStartedAt = 0L;
         accumulatedPausedDurationMs = 0L;
+        currentSegmentStartTimelineMs = 0L;
         clearRecordingTimelineState();
 
         // Stop foreground service and cancel notification early to improve
@@ -5383,6 +5395,48 @@ public class RecordingService extends Service {
         return Math.max(0L, anchor - recordingStartTime - accumulatedPausedDurationMs);
     }
 
+    /**
+     * Stores a bookmark for the moment currently being recorded.
+     *
+     * <p>The position is taken relative to the <em>active segment</em> so it can be
+     * used directly as a seek target when that file is played back. Ignored when no
+     * recording is running, because there would be no file to attach it to.</p>
+     */
+    private void addBookmarkAtCurrentPosition() {
+        if (recordingState != RecordingState.IN_PROGRESS && recordingState != RecordingState.PAUSED) {
+            FLog.w(TAG, "addBookmarkAtCurrentPosition: ignored — no active recording");
+            return;
+        }
+        String mediaUri = getCurrentRecordingMediaUri();
+        if (mediaUri == null) {
+            FLog.w(TAG, "addBookmarkAtCurrentPosition: ignored — no active segment");
+            return;
+        }
+        try {
+            String mediaName = com.fadcam.bookmarks.BookmarkRepository
+                    .resolveMediaName(this, Uri.parse(mediaUri));
+            if (mediaName == null) {
+                FLog.w(TAG, "addBookmarkAtCurrentPosition: could not resolve a name for " + mediaUri);
+                return;
+            }
+            long positionMs = Math.max(0L, getEffectiveTimelineMs() - currentSegmentStartTimelineMs);
+            int total = com.fadcam.bookmarks.BookmarkRepository.getInstance(this)
+                    .add(mediaName, positionMs);
+            broadcastOnBookmarkAdded(positionMs, total);
+        } catch (Exception e) {
+            FLog.e(TAG, "Failed to add bookmark for " + mediaUri, e);
+        }
+    }
+
+    /** Tells the UI that a bookmark landed, so it can confirm it to the user. */
+    private void broadcastOnBookmarkAdded(long positionMs, int total) {
+        Intent broadcastIntent = new Intent(Constants.BROADCAST_ON_BOOKMARK_ADDED);
+        broadcastIntent.putExtra(Constants.EXTRA_BOOKMARK_POSITION_MS, positionMs);
+        broadcastIntent.putExtra(Constants.EXTRA_BOOKMARK_COUNT, total);
+        androidx.localbroadcastmanager.content.LocalBroadcastManager.getInstance(this)
+                .sendBroadcast(broadcastIntent);
+    }
+
     // --- End Helper Methods ---
 
     // --- Broadcasts ---
@@ -6741,6 +6795,7 @@ public class RecordingService extends Service {
                 recordingStartTime = SystemClock.elapsedRealtime();
                 pauseStartedAt = 0L;
                 accumulatedPausedDurationMs = 0L;
+                currentSegmentStartTimelineMs = 0L;
 
                 persistRecordingTimelineState();
                 startDurationLimitSession();
@@ -6949,6 +7004,9 @@ public class RecordingService extends Service {
         @Override
         public void onSegmentRollover(int nextSegmentNumber) {
             FLog.d(TAG, "GLSegmentCallback.onSegmentRollover called for segment " + nextSegmentNumber);
+            // Anchor the new segment on the session timeline so bookmarks taken
+            // after this point are stored relative to the new file, not the session.
+            currentSegmentStartTimelineMs = getEffectiveTimelineMs();
             String storageMode = sharedPreferencesManager.getStorageMode();
             VideoCodec selectedCodec = sharedPreferencesManager.getVideoCodec();
             if (SharedPreferencesManager.STORAGE_MODE_CUSTOM.equals(storageMode)) {

--- a/app/src/main/java/com/fadcam/ui/FullscreenPreviewActivity.java
+++ b/app/src/main/java/com/fadcam/ui/FullscreenPreviewActivity.java
@@ -116,6 +116,9 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
     private MaterialButton btnTapFocusToggle;
     private View containerFullscreenMirror;
     private View containerFullscreenShot;
+    private View containerFullscreenBookmark;
+    private TextView btnFullscreenBookmark;
+    private TextView tvFullscreenBookmarkCount;
     private TextView labelFullscreenMirror;
     private TextView labelFullscreenShot;
     private View containerZoomHud;
@@ -158,6 +161,13 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
     private boolean isPreviewOnlyActive = false;
     private boolean isPreviewAttachedInRecording = true;
     private boolean tapToFocusEnabled = true;
+    /**
+     * Bookmarks confirmed by the recording service while this screen was open.
+     * -1 means "not known yet" — the badge stays hidden rather than claiming a
+     * count this screen has not been told, since the recording may already carry
+     * marks placed from the home preview.
+     */
+    private int knownBookmarkCount = -1;
     private float pinchZoomRatio = 1.0f;
     private long lastZoomDispatchMs = 0L;
     private float lastDispatchedZoomRatio = -1f;
@@ -206,6 +216,17 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         }
     };
 
+    private boolean bookmarkReceiverRegistered = false;
+    private final BroadcastReceiver bookmarkReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (intent == null) return;
+            onBookmarkAdded(
+                    intent.getLongExtra(Constants.EXTRA_BOOKMARK_POSITION_MS, 0L),
+                    intent.getIntExtra(Constants.EXTRA_BOOKMARK_COUNT, Math.max(0, knownBookmarkCount) + 1));
+        }
+    };
+
     private boolean recordingStateReceiverRegistered = false;
     private final BroadcastReceiver recordingStateReceiver = new BroadcastReceiver() {
         @Override
@@ -218,7 +239,14 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
                 isRecordingActive = true;
             } else if (Constants.BROADCAST_ON_RECORDING_RESUMED.equals(action)
                     || Constants.BROADCAST_ON_RECORDING_STARTED.equals(action)
-                    || Constants.BROADCAST_ON_DUAL_RECORDING_RESUMED.equals(action)) {
+                    || Constants.BROADCAST_ON_DUAL_RECORDING_RESUMED.equals(action)
+                    || Constants.BROADCAST_ON_DUAL_RECORDING_STARTED.equals(action)) {
+                if (Constants.BROADCAST_ON_RECORDING_STARTED.equals(action)
+                        || Constants.BROADCAST_ON_DUAL_RECORDING_STARTED.equals(action)) {
+                    // Fresh session — the badge starts from "not known yet" again.
+                    knownBookmarkCount = -1;
+                    updateBookmarkUi();
+                }
                 isRecordingPaused = false;
                 isRecordingActive = true;
                 isPreviewAttachedInRecording = true;
@@ -230,6 +258,8 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
                 isRecordingPaused = false;
                 isRecordingActive = false;
                 isPreviewOnlyActive = false;
+                knownBookmarkCount = -1;
+                updateBookmarkUi();
             } else if (Constants.BROADCAST_ON_RECORDING_STATE_CALLBACK.equals(action)) {
                 try {
                     RecordingState state = (RecordingState) intent.getSerializableExtra(
@@ -253,7 +283,10 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
                         isRecordingPaused = false;
                         isRecordingActive = true;
                         isPreviewAttachedInRecording = true;
-                    } else {
+                    } else if (!isDualRecordingRunning()) {
+                        // The single-camera service answers even while dual camera
+                        // owns the recording; taking its idle state at face value
+                        // would make the controls look idle mid-recording.
                         isRecordingPaused = false;
                         isRecordingActive = false;
                     }
@@ -281,6 +314,7 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
             }
             updatePauseResumeButton();
             updateMirrorButtonVisibilityAndState();
+            updateBookmarkButtonVisibility();
             updatePreviewHintVisibility();
         }
     };
@@ -318,6 +352,7 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         setupMirrorButton();
         setupPauseResumeButton();
         setupCaptureShotButton();
+        setupBookmarkButton();
         setupZoomHud();
         setupSystemInsets();
         setupBackPressedHandler();
@@ -326,7 +361,9 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         applyFullscreenAvatarState(false, false);
         registerTorchReceiver();
         registerRecordingStateReceiver();
+        registerBookmarkReceiver();
         requestRecordingStateSync();
+        syncDualRecordingState();
         scheduleAutoHide();
     }
 
@@ -340,6 +377,8 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         syncZoomUiStateFromPrefs(false);
         updatePreviewHintVisibility();
         requestRecordingStateSync();
+        syncDualRecordingState();
+        updateBookmarkButtonVisibility();
         syncPreviewWithPreference();
         if (previewSurface != null && textureView != null && textureView.isAvailable()) {
             sendSurfaceToService(previewSurface,
@@ -364,6 +403,7 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         autoHideHandler.removeCallbacks(autoHideRunnable);
         unregisterTorchReceiver();
         unregisterRecordingStateReceiver();
+        unregisterBookmarkReceiver();
         // Release local surface only — do NOT send null to service.
         // HomeFragment will immediately push its own surface when it resumes,
         // avoiding the race condition that causes "stuck preview" frames.
@@ -432,6 +472,9 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         labelFullscreenMirror = findViewById(R.id.labelFullscreenMirror);
         containerFullscreenShot = findViewById(R.id.containerFullscreenShot);
         labelFullscreenShot = findViewById(R.id.labelFullscreenShot);
+        containerFullscreenBookmark = findViewById(R.id.containerFullscreenBookmark);
+        btnFullscreenBookmark = findViewById(R.id.btnFullscreenBookmark);
+        tvFullscreenBookmarkCount = findViewById(R.id.tvFullscreenBookmarkCount);
         containerZoomHud = findViewById(R.id.containerZoomHud);
         textZoomHud = findViewById(R.id.textZoomHud);
         btnZoomReset = findViewById(R.id.btnZoomReset);
@@ -460,6 +503,93 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
             startService(intent);
             scheduleAutoHide();
         });
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Bookmark — mark the moment being recorded, without leaving fullscreen
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private void setupBookmarkButton() {
+        if (btnFullscreenBookmark == null) return;
+        btnFullscreenBookmark.setOnClickListener(v -> {
+            if (!isRecordingSessionActive()) return;
+            try {
+                if (com.fadcam.Utils.hapticsAllowedForUi(this)) {
+                    v.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM);
+                }
+            } catch (Exception ignored) { }
+            Intent intent = new Intent(this, getTargetServiceClass());
+            intent.setAction(Constants.INTENT_ACTION_ADD_BOOKMARK);
+            startService(intent);
+            scheduleAutoHide();
+        });
+        updateBookmarkUi();
+        updateBookmarkButtonVisibility();
+    }
+
+    /** Confirms a stored bookmark: shows the running total and where it landed. */
+    private void onBookmarkAdded(long positionMs, int total) {
+        knownBookmarkCount = total;
+        updateBookmarkUi();
+        Toast.makeText(this,
+                getString(R.string.quick_bookmark_added_toast,
+                        com.fadcam.ui.faditor.util.TimeFormatter.formatAuto(positionMs)),
+                Toast.LENGTH_SHORT).show();
+    }
+
+    /** Reflects the known bookmark count on the icon and the badge under it. */
+    private void updateBookmarkUi() {
+        if (btnFullscreenBookmark != null) {
+            btnFullscreenBookmark.setText(knownBookmarkCount > 0 ? "bookmark_added" : "bookmark_add");
+        }
+        if (tvFullscreenBookmarkCount != null) {
+            tvFullscreenBookmarkCount.setVisibility(knownBookmarkCount >= 0 ? View.VISIBLE : View.GONE);
+            if (knownBookmarkCount >= 0) {
+                tvFullscreenBookmarkCount.setText(String.valueOf(knownBookmarkCount));
+            }
+        }
+    }
+
+    /**
+     * Bookmarking needs a file to attach the mark to, so the button only shows
+     * while a recording — single or dual camera — is running or paused, and it
+     * follows the same auto-hide as the rest of the controls.
+     */
+    private void updateBookmarkButtonVisibility() {
+        if (containerFullscreenBookmark == null) return;
+        boolean show = isRecordingSessionActive() && controlsVisible;
+        containerFullscreenBookmark.setVisibility(show ? View.VISIBLE : View.GONE);
+    }
+
+    /**
+     * Whether something is being recorded right now. Dual recording is read off
+     * the running service: it broadcasts state changes but, unlike the
+     * single-camera service, answers no state request, so a dual session that
+     * began before this screen opened would otherwise go unnoticed.
+     */
+    private boolean isRecordingSessionActive() {
+        return isRecordingActive || isRecordingPaused || isDualRecordingRunning();
+    }
+
+    private void registerBookmarkReceiver() {
+        if (bookmarkReceiverRegistered) return;
+        try {
+            androidx.localbroadcastmanager.content.LocalBroadcastManager.getInstance(this)
+                    .registerReceiver(bookmarkReceiver,
+                            new IntentFilter(Constants.BROADCAST_ON_BOOKMARK_ADDED));
+            bookmarkReceiverRegistered = true;
+        } catch (Exception e) {
+            FLog.e(TAG, "Error registering bookmark receiver", e);
+        }
+    }
+
+    private void unregisterBookmarkReceiver() {
+        if (!bookmarkReceiverRegistered) return;
+        try {
+            androidx.localbroadcastmanager.content.LocalBroadcastManager.getInstance(this)
+                    .unregisterReceiver(bookmarkReceiver);
+        } catch (Exception ignored) { }
+        bookmarkReceiverRegistered = false;
     }
 
     private void setupTextureView() {
@@ -969,6 +1099,7 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         filter.addAction(Constants.BROADCAST_ON_RECORDING_STATE_CALLBACK);
         filter.addAction(Constants.BROADCAST_ON_PREVIEW_ONLY_STARTED);
         filter.addAction(Constants.BROADCAST_ON_PREVIEW_ONLY_STOPPED);
+        filter.addAction(Constants.BROADCAST_ON_DUAL_RECORDING_STARTED);
         filter.addAction(Constants.BROADCAST_ON_DUAL_RECORDING_RESUMED);
         filter.addAction(Constants.BROADCAST_ON_DUAL_RECORDING_PAUSED);
         filter.addAction(Constants.BROADCAST_ON_DUAL_RECORDING_STOPPED);
@@ -990,6 +1121,27 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
             unregisterReceiver(recordingStateReceiver);
         } catch (Exception ignored) { }
         recordingStateReceiverRegistered = false;
+    }
+
+    /**
+     * Adopts an already-running dual recording.
+     *
+     * <p>The dual service broadcasts its state changes but answers no state
+     * request, so a session that began before this screen opened would leave the
+     * controls looking idle — the dock would offer "Start" mid-recording, and the
+     * bookmark button would stay hidden.</p>
+     */
+    private void syncDualRecordingState() {
+        if (isRecordingActive || !isDualRecordingRunning()) {
+            return;
+        }
+        isRecordingActive = true;
+        isRecordingPaused = prefs.sharedPreferences
+                .getLong(Constants.PREF_RECORDING_PAUSE_STARTED_AT, 0L) > 0L;
+        isPreviewAttachedInRecording = true;
+        updatePauseResumeButton();
+        updateBookmarkButtonVisibility();
+        updatePreviewHintVisibility();
     }
 
     private void requestRecordingStateSync() {
@@ -1816,6 +1968,7 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         animateBar(topBar, true);
         animateBar(bottomBar, true);
         animateBar(containerFullscreenShot, true);
+        animateBar(containerFullscreenBookmark, isRecordingSessionActive());
         animateBar(containerFullscreenMirror, prefs.getCameraSelection() == CameraType.FRONT);
     }
 
@@ -1825,6 +1978,7 @@ public class FullscreenPreviewActivity extends AppCompatActivity {
         animateBar(topBar, false);
         animateBar(bottomBar, false);
         animateBar(containerFullscreenShot, false);
+        animateBar(containerFullscreenBookmark, false);
         animateBar(containerFullscreenMirror, false);
     }
 

--- a/app/src/main/java/com/fadcam/ui/HomeFragment.java
+++ b/app/src/main/java/com/fadcam/ui/HomeFragment.java
@@ -323,6 +323,11 @@ public class HomeFragment extends BaseFragment {
     private View btnCaptureShotPreview;
     private View btnQuickMuteAudio;
     private View btnQuickTimer;
+    private View btnQuickBookmark;
+    private android.widget.TextView ivQuickBookmarkIcon;
+    private com.fadcam.ui.utils.AnimatedTextView tvQuickBookmarkCount;
+    /** Bookmarks taken in the running recording — resets with every session. */
+    private int sessionBookmarkCount = 0;
     private TextView tvQuickTimerValue;
     private TextView ivQuickMuteIcon;
     private TextView tvQuickMuteLabel;
@@ -477,6 +482,7 @@ public class HomeFragment extends BaseFragment {
     private BroadcastReceiver broadcastOnMirrorChanged;
     private BroadcastReceiver broadcastOnZoomChanged;
     private BroadcastReceiver broadcastOnExposureChanged;
+    private BroadcastReceiver broadcastOnBookmarkAdded;
     private volatile boolean isCameraSwitchInProgress = false;
     private volatile long lastCameraSwitchCompleteTime = 0; // Debounce duplicate toasts
     private volatile long lastCameraSwitchTime = 0; // Track when switch completed to prevent button disable
@@ -2433,6 +2439,10 @@ public class HomeFragment extends BaseFragment {
                     // Get timestamp from the service with current time as fallback
                     applyRecordingTimelineFromIntent(i);
 
+                    // Fresh session — the bookmark badge starts from zero again.
+                    sessionBookmarkCount = 0;
+                    updateQuickBookmarkUi();
+
                     // Perform non-UI actions previously in onRecordingStarted(true)
                     // WakeLock moved to service
                     setVideoBitrate();
@@ -3371,6 +3381,17 @@ public class HomeFragment extends BaseFragment {
             }
         };
 
+        // Receiver: a bookmark was stored for the running recording
+        broadcastOnBookmarkAdded = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (!isAdded() || intent == null) return;
+                onBookmarkAdded(
+                        intent.getLongExtra(Constants.EXTRA_BOOKMARK_POSITION_MS, 0L),
+                        intent.getIntExtra(Constants.EXTRA_BOOKMARK_COUNT, sessionBookmarkCount + 1));
+            }
+        };
+
         // Receiver: mirror state changed from web dashboard
         broadcastOnMirrorChanged = new BroadcastReceiver() {
             @Override
@@ -3431,7 +3452,8 @@ public class HomeFragment extends BaseFragment {
     private void registerCameraSwitchReceivers(Context context) {
         if (broadcastOnCameraSwitchStarted == null 
                 || broadcastOnCameraSwitchComplete == null 
-                || broadcastOnCameraSwitchFailed == null) {
+                || broadcastOnCameraSwitchFailed == null
+                || broadcastOnBookmarkAdded == null) {
             initializeCameraSwitchReceivers();
         }
 
@@ -3442,6 +3464,7 @@ public class HomeFragment extends BaseFragment {
             IntentFilter mirrorFilter = new IntentFilter(Constants.BROADCAST_ON_MIRROR_CHANGED);
             IntentFilter zoomFilter = new IntentFilter(Constants.BROADCAST_ON_ZOOM_CHANGED);
             IntentFilter exposureFilter = new IntentFilter(Constants.BROADCAST_ON_EXPOSURE_CHANGED);
+            IntentFilter bookmarkFilter = new IntentFilter(Constants.BROADCAST_ON_BOOKMARK_ADDED);
 
             androidx.localbroadcastmanager.content.LocalBroadcastManager lbm =
                     androidx.localbroadcastmanager.content.LocalBroadcastManager.getInstance(context);
@@ -3451,6 +3474,7 @@ public class HomeFragment extends BaseFragment {
             lbm.registerReceiver(broadcastOnMirrorChanged, mirrorFilter);
             lbm.registerReceiver(broadcastOnZoomChanged, zoomFilter);
             lbm.registerReceiver(broadcastOnExposureChanged, exposureFilter);
+            lbm.registerReceiver(broadcastOnBookmarkAdded, bookmarkFilter);
             FLog.d(TAG, "Camera switch + control receivers registered successfully");
         } catch (Exception e) {
             FLog.e(TAG, "Error registering camera switch receivers", e);
@@ -3479,6 +3503,9 @@ public class HomeFragment extends BaseFragment {
             }
             if (broadcastOnExposureChanged != null) {
                 androidx.localbroadcastmanager.content.LocalBroadcastManager.getInstance(context).unregisterReceiver(broadcastOnExposureChanged);
+            }
+            if (broadcastOnBookmarkAdded != null) {
+                androidx.localbroadcastmanager.content.LocalBroadcastManager.getInstance(context).unregisterReceiver(broadcastOnBookmarkAdded);
             }
             FLog.d(TAG, "Camera switch + control receivers unregistered");
         } catch (Exception e) {
@@ -10504,6 +10531,9 @@ public class HomeFragment extends BaseFragment {
         btnCaptureShotPreview = view.findViewById(R.id.btnCaptureShotPreview);
         btnQuickMuteAudio = view.findViewById(R.id.btnQuickMuteAudio);
         btnQuickTimer = view.findViewById(R.id.btnQuickTimer);
+        btnQuickBookmark = view.findViewById(R.id.btnQuickBookmark);
+        ivQuickBookmarkIcon = view.findViewById(R.id.ivQuickBookmarkIcon);
+        tvQuickBookmarkCount = view.findViewById(R.id.tvQuickBookmarkCount);
         tvQuickTimerValue = view.findViewById(R.id.tvQuickTimerValue);
         ivQuickMuteIcon = view.findViewById(R.id.ivQuickMuteIcon);
         tvQuickMuteLabel = view.findViewById(R.id.tvQuickMuteLabel);
@@ -10517,6 +10547,7 @@ public class HomeFragment extends BaseFragment {
         setupCaptureShotButton();
         setupQuickMuteButton();
         setupQuickTimerButton();
+        setupQuickBookmarkButton();
         setupQuickActionsReorder();
         setupPreviewZoomHud();
         // NOTE: quick-action press haptics live inside the reorder gesture's
@@ -11193,6 +11224,63 @@ public class HomeFragment extends BaseFragment {
         }
     }
 
+    // ─── Bookmark quick action ────────────────────────────────────────────
+
+    /**
+     * Wires the bookmark quick-action. A tap asks the recording service to mark
+     * the moment currently being recorded; the service answers with a broadcast
+     * carrying the running total, which drives the small count under the icon.
+     */
+    private void setupQuickBookmarkButton() {
+        if (btnQuickBookmark == null) return;
+        btnQuickBookmark.setOnClickListener(v -> {
+            if (!isRecordingOrPaused()) {
+                return;
+            }
+            try {
+                if (com.fadcam.Utils.hapticsAllowedForUi(v.getContext())) {
+                    v.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM);
+                }
+            } catch (Exception ignored) {
+            }
+            try {
+                Intent intent = new Intent(requireContext(), RecordingService.class);
+                intent.setAction(Constants.INTENT_ACTION_ADD_BOOKMARK);
+                requireContext().startService(intent);
+            } catch (Exception e) {
+                FLog.w(TAG, "Failed to dispatch bookmark request: " + e.getMessage());
+            }
+        });
+        updateQuickBookmarkUi();
+    }
+
+    /**
+     * Confirms a stored bookmark: refreshes the count badge and tells the user
+     * where the mark landed.
+     *
+     * @param positionMs offset the bookmark was stored at, in milliseconds
+     * @param total      how many bookmarks the active recording now has
+     */
+    private void onBookmarkAdded(long positionMs, int total) {
+        sessionBookmarkCount = total;
+        updateQuickBookmarkUi();
+        if (!isAdded() || getContext() == null) return;
+        Toast.makeText(requireContext(),
+                getString(R.string.quick_bookmark_added_toast,
+                        com.fadcam.ui.faditor.util.TimeFormatter.formatAuto(positionMs)),
+                Toast.LENGTH_SHORT).show();
+    }
+
+    /** Reflects the session bookmark count on the quick-action badge. */
+    private void updateQuickBookmarkUi() {
+        if (tvQuickBookmarkCount != null) {
+            tvQuickBookmarkCount.setText(String.valueOf(sessionBookmarkCount));
+        }
+        if (ivQuickBookmarkIcon != null) {
+            ivQuickBookmarkIcon.setText(sessionBookmarkCount > 0 ? "bookmark_added" : "bookmark_add");
+        }
+    }
+
     // ─── Quick-actions rearrange (hold → drag → release) ───────────────────
 
     /**
@@ -11225,7 +11313,7 @@ public class HomeFragment extends BaseFragment {
             }
         });
 
-        View[] buttons = { btnQuickMuteAudio, btnFullscreenPreview, btnCaptureShotPreview, btnQuickTimer };
+        View[] buttons = quickActionButtons();
         for (final View b : buttons) {
             if (b == null) continue;
             b.setOnTouchListener((v, event) -> handleQuickActionGesture(v, event));
@@ -11260,7 +11348,7 @@ public class HomeFragment extends BaseFragment {
         int padL = quickActionsRow.getPaddingLeft();
         int padR = quickActionsRow.getPaddingRight();
         int contentW = rowW - padL - padR;
-        quickSlotCount = Math.max(4, contentW / quickSlotWidth); // min 4 slots (mute, full, fadshot, timer)
+        quickSlotCount = Math.max(5, contentW / quickSlotWidth); // min 5 slots (timer, mute, full, fadshot, bookmark)
         // Equal spacing across the padded content area — symmetric on both sides.
         quickSlotStep = contentW / (float) quickSlotCount;
         quickSlotMap.clear();
@@ -11314,7 +11402,7 @@ public class HomeFragment extends BaseFragment {
         // fadshot) so the row looks organized instead of cluttered.
         // Any button missing from the saved slots (corrupt/outdated data) is
         // placed into the default position so the layout is never broken.
-        View[] buttons = { btnQuickTimer, btnQuickMuteAudio, btnFullscreenPreview, btnCaptureShotPreview };
+        View[] buttons = { btnQuickTimer, btnQuickMuteAudio, btnFullscreenPreview, btnCaptureShotPreview, btnQuickBookmark };
         int nextSlot = quickSlotCount - (buttons.length - 1);
         for (View b : buttons) {
             if (b == null) continue;
@@ -11600,7 +11688,7 @@ public class HomeFragment extends BaseFragment {
         int padL = quickActionsRow.getPaddingLeft();
         int padR = quickActionsRow.getPaddingRight();
         int contentW = rowW - padL - padR;
-        quickSlotCount = Math.max(4, contentW / quickSlotWidth); // min 4 slots (mute, full, fadshot, timer)
+        quickSlotCount = Math.max(5, contentW / quickSlotWidth); // min 5 slots (timer, mute, full, fadshot, bookmark)
         quickSlotStep = contentW / (float) quickSlotCount;
         // Skeleton mirrors the real button: icon-shaped ghost + label bar ghost.
         int outlineSize = Math.round(getResources().getDimension(R.dimen.home_quick_icon_size));
@@ -11702,6 +11790,7 @@ public class HomeFragment extends BaseFragment {
         if ("full".equals(token)) return R.id.btnFullscreenPreview;
         if ("fadshot".equals(token)) return R.id.btnCaptureShotPreview;
         if ("timer".equals(token)) return R.id.btnQuickTimer;
+        if ("bookmark".equals(token)) return R.id.btnQuickBookmark;
         return 0;
     }
 
@@ -11710,7 +11799,20 @@ public class HomeFragment extends BaseFragment {
         if (id == R.id.btnFullscreenPreview) return "full";
         if (id == R.id.btnCaptureShotPreview) return "fadshot";
         if (id == R.id.btnQuickTimer) return "timer";
+        if (id == R.id.btnQuickBookmark) return "bookmark";
         return null;
+    }
+
+    /**
+     * Every quick-action button, in no particular order. Single source of truth
+     * for the gesture wiring, the jiggle animation and the slot bookkeeping.
+     *
+     * @return the quick-action button views (entries may be {@code null} before
+     *         the view hierarchy is bound)
+     */
+    private View[] quickActionButtons() {
+        return new View[] { btnQuickMuteAudio, btnFullscreenPreview, btnCaptureShotPreview,
+                btnQuickTimer, btnQuickBookmark };
     }
 
     private void setQuickActionsEditMode(boolean edit) {
@@ -11802,7 +11904,7 @@ public class HomeFragment extends BaseFragment {
 
     private void startQuickActionJiggle(View exclude) {
         stopQuickActionJiggle();
-        View[] buttons = { btnQuickMuteAudio, btnFullscreenPreview, btnCaptureShotPreview, btnQuickTimer };
+        View[] buttons = quickActionButtons();
         java.util.Random r = new java.util.Random();
         for (View b : buttons) {
             if (b == null || b == exclude) continue;
@@ -11825,7 +11927,7 @@ public class HomeFragment extends BaseFragment {
             if (a != null) a.cancel();
         }
         quickJiggleAnimators.clear();
-        View[] buttons = { btnQuickMuteAudio, btnFullscreenPreview, btnCaptureShotPreview, btnQuickTimer };
+        View[] buttons = quickActionButtons();
         for (View b : buttons) {
             if (b != null) b.setRotation(0f);
         }
@@ -11921,6 +12023,13 @@ public class HomeFragment extends BaseFragment {
             } catch (Exception ignored) {
             }
             btnQuickMuteAudio.setVisibility((show && audioEnabled) ? View.VISIBLE : View.GONE);
+        }
+        // Bookmarking needs a file to attach the mark to, so it only appears
+        // while a normal recording is running or paused.
+        if (btnQuickBookmark != null) {
+            boolean canBookmark = isRecordingOrPaused() && !isDualRecordingActive;
+            btnQuickBookmark.setVisibility(canBookmark ? View.VISIBLE : View.GONE);
+            updateQuickBookmarkUi();
         }
         // Keep the preview hint clear of the icon row whenever it appears/disappears.
         updatePreviewHintPosition();

--- a/app/src/main/java/com/fadcam/ui/HomeFragment.java
+++ b/app/src/main/java/com/fadcam/ui/HomeFragment.java
@@ -2629,6 +2629,9 @@ public class HomeFragment extends BaseFragment {
                     isDualRecordingActive = true;
                     recordingState = RecordingState.IN_PROGRESS;
                     applyRecordingTimelineFromIntent(i);
+                    // Fresh session — the bookmark badge starts from zero again.
+                    sessionBookmarkCount = 0;
+                    updateQuickBookmarkUi();
                     setUIForRecordingActive();
                     if (getContext() != null) {
                         Utils.showQuickToast(requireContext(), R.string.dual_recording_started);
@@ -11244,7 +11247,8 @@ public class HomeFragment extends BaseFragment {
             } catch (Exception ignored) {
             }
             try {
-                Intent intent = new Intent(requireContext(), RecordingService.class);
+                Intent intent = new Intent(requireContext(),
+                        isDualRecordingActive ? DualCameraRecordingService.class : RecordingService.class);
                 intent.setAction(Constants.INTENT_ACTION_ADD_BOOKMARK);
                 requireContext().startService(intent);
             } catch (Exception e) {
@@ -12025,10 +12029,9 @@ public class HomeFragment extends BaseFragment {
             btnQuickMuteAudio.setVisibility((show && audioEnabled) ? View.VISIBLE : View.GONE);
         }
         // Bookmarking needs a file to attach the mark to, so it only appears
-        // while a normal recording is running or paused.
+        // while a recording is running or paused — single or dual camera alike.
         if (btnQuickBookmark != null) {
-            boolean canBookmark = isRecordingOrPaused() && !isDualRecordingActive;
-            btnQuickBookmark.setVisibility(canBookmark ? View.VISIBLE : View.GONE);
+            btnQuickBookmark.setVisibility(isRecordingOrPaused() ? View.VISIBLE : View.GONE);
             updateQuickBookmarkUi();
         }
         // Keep the preview hint clear of the icon row whenever it appears/disappears.

--- a/app/src/main/java/com/fadcam/ui/RecordsAdapter.java
+++ b/app/src/main/java/com/fadcam/ui/RecordsAdapter.java
@@ -1752,6 +1752,10 @@ public class RecordsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             }
 
             if (renameSuccess && newUri != null) {
+                // Bookmarks are keyed by display name — re-key them so the marks
+                // stay attached to the recording the user just renamed.
+                com.fadcam.bookmarks.BookmarkRepository.getInstance(context)
+                        .move(videoItem.displayName, newFullName);
                 final Uri finalNewUri = newUri; // Create an effectively final variable
                 VideoItem updatedItem = new VideoItem(
                         finalNewUri,

--- a/app/src/main/java/com/fadcam/ui/RecordsAdapter.java
+++ b/app/src/main/java/com/fadcam/ui/RecordsAdapter.java
@@ -1679,6 +1679,9 @@ public class RecordsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         Uri videoUri = videoItem.uri;
         boolean renameSuccess = false;
         Uri newUri = null;
+        // The name the file actually ended up with: collision handling can append a
+        // suffix, and anything keyed by display name (bookmarks) must follow the file.
+        String effectiveName = newFullName;
 
         try {
             FLog.d(TAG, "Attempting rename. URI: " + videoUri + ", Scheme: " + videoUri.getScheme() + ", New Name: "
@@ -1699,6 +1702,7 @@ public class RecordsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 if (oldFile.renameTo(newFile)) {
                     renameSuccess = true;
                     newUri = Uri.fromFile(newFile);
+                    effectiveName = uniqueName;
                     FLog.i(TAG, "Renamed file system file successfully to: " + uniqueName);
                 } else {
                     FLog.e(TAG, "File.renameTo() failed for " + oldFile.getPath());
@@ -1722,6 +1726,7 @@ public class RecordsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 newUri = DocumentsContract.renameDocument(context.getContentResolver(), videoUri, finalName);
                 if (newUri != null) {
                     renameSuccess = true;
+                    effectiveName = finalName;
                     FLog.i(TAG, "Renamed SAF document successfully to: " + finalName + ", New URI: " + newUri);
                 } else {
                     FLog.w(TAG, "DocumentsContract.renameDocument returned null for: " + videoUri + " to '" + finalName
@@ -1735,6 +1740,7 @@ public class RecordsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                         FLog.w(TAG, "Rename check: File with new name exists under original URI. Assuming success.");
                         newUri = checkDoc.getUri();
                         renameSuccess = true;
+                        effectiveName = finalName;
                     } else { // Check if a new file with the new name exists in the parent
                         DocumentFile parent = checkDoc != null ? checkDoc.getParentFile() : null;
                         if (parent != null) {
@@ -1743,6 +1749,7 @@ public class RecordsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                 FLog.w(TAG, "Rename check: File with new name exists in parent. Assuming success.");
                                 newUri = renamedFile.getUri();
                                 renameSuccess = true;
+                                effectiveName = finalName;
                             }
                         }
                     }
@@ -1755,11 +1762,11 @@ public class RecordsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 // Bookmarks are keyed by display name — re-key them so the marks
                 // stay attached to the recording the user just renamed.
                 com.fadcam.bookmarks.BookmarkRepository.getInstance(context)
-                        .move(videoItem.displayName, newFullName);
+                        .move(videoItem.displayName, effectiveName);
                 final Uri finalNewUri = newUri; // Create an effectively final variable
                 VideoItem updatedItem = new VideoItem(
                         finalNewUri,
-                        newFullName,
+                        effectiveName,
                         videoItem.size,
                         System.currentTimeMillis(),
                         videoItem.category,

--- a/app/src/main/java/com/fadcam/ui/VideoPlayerActivity.java
+++ b/app/src/main/java/com/fadcam/ui/VideoPlayerActivity.java
@@ -12,6 +12,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
@@ -32,7 +33,8 @@ import android.media.AudioManager;
 import android.media.MediaMetadataRetriever;
 import android.provider.Settings;
 
-public class VideoPlayerActivity extends AppCompatActivity {
+public class VideoPlayerActivity extends AppCompatActivity
+    implements com.fadcam.bookmarks.ui.BookmarksBottomSheet.Listener {
 
     private static final String TAG = "VideoPlayerActivity";
 
@@ -61,6 +63,10 @@ public class VideoPlayerActivity extends AppCompatActivity {
     private com.fadcam.ui.custom.AudioWaveformView audioWaveformView;
     private android.net.Uri currentVideoUri;
     private com.google.android.material.slider.Slider timeSlider;
+    private com.fadcam.bookmarks.ui.BookmarkMarkersView bookmarkMarkersView;
+    private android.widget.TextView bookmarkButton;
+    /** Storage key of the video being played; {@code null} until it is resolved. */
+    private String bookmarkMediaName;
     // Cached duration for fragmented MP4s where player.getDuration() returns TIME_UNSET
     private long cachedDurationMs = C.TIME_UNSET;
     // Gesture/interaction helpers
@@ -266,6 +272,7 @@ public class VideoPlayerActivity extends AppCompatActivity {
             setupQuickSpeedSettings();
             setupResetZoomButton();
             setupPressAndHoldFor2x();
+            setupBookmarks(videoUri);
         } else {
             // Log error and finish if URI is missing
             FLog.e(
@@ -1514,6 +1521,7 @@ public class VideoPlayerActivity extends AppCompatActivity {
                                     FLog.w(TAG, "Duration still unknown: player=" + player.getDuration() + ", cached=" + cachedDurationMs);
                                 }
                             }
+                            syncBookmarkMarkerGeometry();
                         } catch (Exception e) {
                             FLog.e(TAG, "Error in periodic slider update", e);
                         }
@@ -1681,6 +1689,104 @@ public class VideoPlayerActivity extends AppCompatActivity {
             if (timeBar != null) return timeBar.getVisibility() == View.VISIBLE;
         } catch (Exception ignored) {}
         return false;
+    }
+
+    // --- Recording bookmarks ---
+
+    /**
+     * Wires the bookmark UI for the video being played: the markers drawn over
+     * the time slider and the control-bar button that opens the jump list.
+     *
+     * @param videoUri the media being played
+     */
+    private void setupBookmarks(@NonNull Uri videoUri) {
+        try {
+            bookmarkMediaName = com.fadcam.bookmarks.BookmarkRepository
+                    .resolveMediaName(this, videoUri);
+            if (playerView != null) {
+                bookmarkMarkersView = playerView.findViewById(R.id.bookmark_markers);
+                bookmarkButton = playerView.findViewById(R.id.bookmark_button);
+            }
+            if (bookmarkButton != null) {
+                bookmarkButton.setOnClickListener(v -> showBookmarksSheet());
+            }
+            refreshBookmarks();
+        } catch (Exception e) {
+            FLog.w(TAG, "Could not set up bookmarks for " + videoUri, e);
+        }
+    }
+
+    /** Reloads the stored bookmarks and refreshes the markers and the button. */
+    private void refreshBookmarks() {
+        if (bookmarkMediaName == null) {
+            return;
+        }
+        java.util.List<com.fadcam.bookmarks.Bookmark> bookmarks =
+                com.fadcam.bookmarks.BookmarkRepository.getInstance(this).getAll(bookmarkMediaName);
+        if (bookmarkMarkersView != null) {
+            bookmarkMarkersView.setBookmarks(bookmarks);
+            syncBookmarkMarkerGeometry();
+        }
+        if (bookmarkButton != null) {
+            bookmarkButton.setVisibility(bookmarks.isEmpty() ? View.GONE : View.VISIBLE);
+        }
+    }
+
+    /**
+     * Copies the slider's track geometry and the current duration onto the marker
+     * overlay so every marker stays aligned with the position it refers to.
+     */
+    private void syncBookmarkMarkerGeometry() {
+        if (bookmarkMarkersView == null || timeSlider == null) {
+            return;
+        }
+        try {
+            bookmarkMarkersView.setTrackGeometry(
+                    timeSlider.getLeft() + timeSlider.getTrackSidePadding(),
+                    timeSlider.getTrackWidth());
+            // The slider still carries its layout placeholder (100) until the real
+            // duration arrives; mapping against it would bunch every marker at the
+            // right edge for a frame, so wait for a plausible duration first.
+            float sliderMax = timeSlider.getValueTo();
+            if (sliderMax > 100f) {
+                bookmarkMarkersView.setDurationMs((long) sliderMax);
+            }
+        } catch (Exception e) {
+            FLog.w(TAG, "Could not sync bookmark marker geometry", e);
+        }
+    }
+
+    /** Opens the sheet listing the bookmarks of the current video. */
+    private void showBookmarksSheet() {
+        if (bookmarkMediaName == null || isFinishing()) {
+            return;
+        }
+        try {
+            com.fadcam.bookmarks.ui.BookmarksBottomSheet
+                    .newInstance(bookmarkMediaName)
+                    .show(getSupportFragmentManager(), "bookmarks");
+        } catch (Exception e) {
+            FLog.w(TAG, "Could not open the bookmarks sheet", e);
+        }
+    }
+
+    @Override
+    public void onBookmarkSelected(long positionMs) {
+        try {
+            com.fadcam.playback.PlayerHolder.getInstance().seekToPosition(positionMs);
+            lastSeekPositionMs = positionMs;
+            if (timeSlider != null) {
+                timeSlider.setValue(Math.min(timeSlider.getValueTo(),
+                        Math.max(timeSlider.getValueFrom(), (float) positionMs)));
+            }
+        } catch (Exception e) {
+            FLog.w(TAG, "Could not seek to bookmark at " + positionMs + "ms", e);
+        }
+    }
+
+    @Override
+    public void onBookmarksChanged() {
+        refreshBookmarks();
     }
 
     private void setupBackButton() {

--- a/app/src/main/java/com/fadcam/utils/TrashManager.java
+++ b/app/src/main/java/com/fadcam/utils/TrashManager.java
@@ -510,6 +510,11 @@ public class TrashManager {
                         + item.getTrashFileName());
             }
 
+            // The recording is gone for good — drop the bookmarks that pointed
+            // into it so they never resurface on a same-named future recording.
+            com.fadcam.bookmarks.BookmarkRepository.getInstance(context)
+                    .clear(item.getOriginalDisplayName());
+
             // Remove from metadata regardless of file deletion success,
             // as the intent is to remove it from the trash list.
             // If file deletion failed, it's an orphaned file, but metadata should be clean.
@@ -550,6 +555,15 @@ public class TrashManager {
             // Clear metadata anyway, in case it's out of sync
             saveTrashMetadata(context, new ArrayList<>());
             return true;
+        }
+
+        // Everything in the trash is about to go — drop their bookmarks too.
+        com.fadcam.bookmarks.BookmarkRepository bookmarkRepository =
+                com.fadcam.bookmarks.BookmarkRepository.getInstance(context);
+        for (TrashItem item : loadTrashMetadata(context)) {
+            if (item != null) {
+                bookmarkRepository.clear(item.getOriginalDisplayName());
+            }
         }
 
         boolean allFilesDeleted = true;

--- a/app/src/main/res/layout-land/fragment_home.xml
+++ b/app/src/main/res/layout-land/fragment_home.xml
@@ -793,6 +793,60 @@
                         android:shadowRadius="1"/>
                 </LinearLayout>
 
+                <!-- Bookmark button: marks the current moment while recording. -->
+                <LinearLayout
+                    android:id="@+id/btnQuickBookmark"
+                    android:layout_width="44dp"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:gravity="center"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:visibility="gone"
+                    android:background="?attr/selectableItemBackgroundBorderless" android:clipChildren="false" android:clipToPadding="false">
+
+                    <TextView
+                        android:id="@+id/ivQuickBookmarkIcon"
+                        android:layout_width="36dp"
+                        android:layout_height="36dp"
+                        android:background="@drawable/fullscreen_icon_bg_gradient"
+                        android:fontFamily="@font/materialicons"
+                        android:gravity="center"
+                        android:text="bookmark_add"
+                        android:textSize="20sp"
+                        android:textColor="@android:color/white"
+                        android:contentDescription="@string/quick_bookmark_desc" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/quick_bookmark_label"
+                        android:textColor="@android:color/white"
+                        android:textSize="9sp"
+                        android:textStyle="bold"
+                        android:maxLines="2"
+                        android:gravity="center"
+                        android:layout_marginTop="2dp"
+                        android:shadowColor="#BB000000"
+                        android:shadowDx="1"
+                        android:shadowDy="1"
+                        android:shadowRadius="1"/>
+
+                    <com.fadcam.ui.utils.AnimatedTextView
+                        android:id="@+id/tvQuickBookmarkCount"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="0"
+                        android:textColor="#FFD54F"
+                        android:textSize="8sp"
+                        android:fontFamily="monospace"
+                        android:textStyle="bold"
+                        android:maxLines="1"
+                        android:gravity="center"
+                        android:layout_marginTop="1dp"
+                        android:includeFontPadding="false"/>
+                </LinearLayout>
+
             </FrameLayout>
 
                 <LinearLayout

--- a/app/src/main/res/layout/activity_fullscreen_preview.xml
+++ b/app/src/main/res/layout/activity_fullscreen_preview.xml
@@ -616,4 +616,53 @@
             android:textSize="10sp" />
     </LinearLayout>
 
+    <!-- Bookmark the moment being recorded. Kept on the free side of the screen
+         so it never sits over the dual-camera PiP overlay, and only shown while a
+         recording (single or dual) is running or paused. -->
+    <LinearLayout
+        android:id="@+id/containerFullscreenBookmark"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|start"
+        android:layout_marginStart="24dp"
+        android:layout_marginBottom="204dp"
+        android:elevation="12dp"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/btnFullscreenBookmark"
+            android:layout_width="52dp"
+            android:layout_height="52dp"
+            android:background="@drawable/fullscreen_icon_bg_gradient"
+            android:clickable="true"
+            android:contentDescription="@string/quick_bookmark_desc"
+            android:focusable="true"
+            android:fontFamily="@font/materialicons"
+            android:gravity="center"
+            android:text="bookmark_add"
+            android:textColor="@android:color/white"
+            android:textSize="24sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/quick_bookmark_label"
+            android:textColor="#B3FFFFFF"
+            android:textSize="10sp" />
+
+        <TextView
+            android:id="@+id/tvFullscreenBookmarkCount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="monospace"
+            android:text="0"
+            android:visibility="gone"
+            android:textColor="#FFD54F"
+            android:textSize="11sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
 </FrameLayout>

--- a/app/src/main/res/layout/bottom_sheet_bookmarks.xml
+++ b/app/src/main/res/layout/bottom_sheet_bookmarks.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="@drawable/picker_bottom_sheet_dark_gradient_bg"
+    android:padding="20dp">
+
+    <!-- Header -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/bookmarks_title"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:textColor="?attr/colorHeading"
+        android:layout_marginBottom="4dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/bookmarks_desc"
+        android:textSize="13sp"
+        android:textColor="@android:color/darker_gray"
+        android:layout_marginBottom="16dp" />
+
+    <TextView
+        android:id="@+id/bookmarks_empty_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/bookmarks_empty"
+        android:textSize="13sp"
+        android:textColor="@android:color/darker_gray"
+        android:visibility="gone"
+        android:layout_marginBottom="8dp" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxHeight="360dp">
+
+        <LinearLayout
+            android:id="@+id/bookmarks_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </ScrollView>
+
+    <TextView
+        android:id="@+id/bookmarks_clear_all"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/bookmarks_clear_all"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        android:textColor="#E43C3C"
+        android:gravity="center"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="@drawable/settings_home_row_bg"
+        android:padding="14dp"
+        android:layout_marginTop="16dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -65,6 +65,15 @@
                     app:labelBehavior="gone"
                     />
 
+                <!-- Bookmark markers. Drawn last so they sit above the track, and
+                     never clickable so scrubbing still reaches the slider. -->
+                <com.fadcam.bookmarks.ui.BookmarkMarkersView
+                    android:id="@+id/bookmark_markers"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clickable="false"
+                    android:focusable="false" />
+
             </FrameLayout>
 
             <LinearLayout
@@ -101,6 +110,21 @@
                     <ImageButton android:id="@id/exo_shuffle" style="@style/ExoStyledControls.Button.Bottom.Shuffle" android:layout_width="wrap_content" android:layout_height="wrap_content" android:visibility="gone"/>
                     <ImageButton android:id="@id/exo_repeat_toggle" style="@style/ExoStyledControls.Button.Bottom.RepeatToggle" android:layout_width="wrap_content" android:layout_height="wrap_content" android:visibility="gone"/>
                     <ImageButton android:id="@id/exo_subtitle" style="@style/ExoStyledControls.Button.Bottom.CC" android:layout_width="wrap_content" android:layout_height="wrap_content" android:visibility="gone"/>
+
+                    <!-- Bookmarks: shown only when the video has marked moments -->
+                    <TextView android:id="@+id/bookmark_button"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:fontFamily="@font/materialicons"
+                        android:gravity="center"
+                        android:text="bookmarks"
+                        android:textSize="20sp"
+                        android:textColor="@android:color/white"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:visibility="gone"
+                        android:contentDescription="@string/bookmarks_title"/>
 
                     <!-- Use a clear settings/tune glyph for playback settings -->
                     <ImageButton android:id="@id/exo_settings"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -915,6 +915,61 @@
                         android:shadowRadius="1"/>
                 </LinearLayout>
 
+                <!-- Bookmark button: marks the current moment while recording.
+                     The value line shows how many marks this recording has. -->
+                <LinearLayout
+                    android:id="@+id/btnQuickBookmark"
+                    android:layout_width="@dimen/home_quick_btn_w"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:gravity="center"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:visibility="gone"
+                    android:background="?attr/selectableItemBackgroundBorderless" android:clipChildren="false" android:clipToPadding="false">
+
+                    <TextView
+                        android:id="@+id/ivQuickBookmarkIcon"
+                        android:layout_width="@dimen/home_quick_icon_size"
+                        android:layout_height="@dimen/home_quick_icon_size"
+                        android:background="@drawable/fullscreen_icon_bg_gradient"
+                        android:fontFamily="@font/materialicons"
+                        android:gravity="center"
+                        android:text="bookmark_add"
+                        android:textSize="@dimen/home_quick_mute_icon"
+                        android:textColor="@android:color/white"
+                        android:contentDescription="@string/quick_bookmark_desc" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/quick_bookmark_label"
+                        android:textColor="@android:color/white"
+                        android:textSize="@dimen/home_quick_label_size"
+                        android:textStyle="bold"
+                        android:maxLines="2"
+                        android:gravity="center"
+                        android:layout_marginTop="2dp"
+                        android:shadowColor="#BB000000"
+                        android:shadowDx="1"
+                        android:shadowDy="1"
+                        android:shadowRadius="1"/>
+
+                    <com.fadcam.ui.utils.AnimatedTextView
+                        android:id="@+id/tvQuickBookmarkCount"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="0"
+                        android:textColor="#FFD54F"
+                        android:textSize="@dimen/home_quick_value_size"
+                        android:fontFamily="monospace"
+                        android:textStyle="bold"
+                        android:maxLines="1"
+                        android:gravity="center"
+                        android:layout_marginTop="1dp"
+                        android:includeFontPadding="false"/>
+                </LinearLayout>
+
             </FrameLayout>
 
 

--- a/app/src/main/res/layout/item_bookmark_row.xml
+++ b/app/src/main/res/layout/item_bookmark_row.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="@drawable/settings_home_row_bg"
+    android:paddingStart="14dp"
+    android:paddingEnd="12dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    android:clickable="true"
+    android:focusable="true">
+
+    <TextView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginEnd="16dp"
+        android:fontFamily="@font/materialicons"
+        android:gravity="center"
+        android:text="bookmark"
+        android:textSize="20sp"
+        android:textColor="#FFD54F" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/bookmark_position"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:fontFamily="monospace"
+            android:textColor="?attr/colorHeading" />
+
+        <TextView
+            android:id="@+id/bookmark_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="@android:color/darker_gray" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/bookmark_delete"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:fontFamily="@font/materialicons"
+        android:gravity="center"
+        android:text="delete"
+        android:textSize="18sp"
+        android:textColor="@android:color/darker_gray"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/bookmarks_delete_desc" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1102,6 +1102,16 @@
     <string name="quick_countdown_label">Countdown</string>
     <string name="quick_countdown_desc">Start recording after a countdown</string>
     <string name="quick_unmute_label">Unmute</string>
+    <!-- Recording bookmarks -->
+    <string name="quick_bookmark_label">Mark</string>
+    <string name="quick_bookmark_desc">Bookmark this moment</string>
+    <string name="quick_bookmark_added_toast">Bookmarked at %1$s</string>
+    <string name="bookmarks_title">Bookmarks</string>
+    <string name="bookmarks_desc">Jump to a bookmarked moment</string>
+    <string name="bookmarks_empty">No bookmarks in this recording yet.</string>
+    <string name="bookmarks_item_label">Mark %1$d</string>
+    <string name="bookmarks_delete_desc">Delete bookmark</string>
+    <string name="bookmarks_clear_all">Clear all bookmarks</string>
     <string name="grid_lines_subtitle">Rule-of-thirds overlay on the preview</string>
     <string name="preview_quick_actions_state_always">Always visible (idle + recording)</string>
     <string name="preview_quick_actions_state_recording_only">Visible only while recording</string>


### PR DESCRIPTION
Closes #314

Lets a moment be marked while a recording is in progress, and surfaces those marks on the playback timeline so they can be jumped to instead of scrubbing through a long video.

## What it does

**While recording** — a new **Mark** button joins the preview quick actions (the same row as Timer / Mute / Full / FadShot, so it drag-reorders and persists like the others). It only appears while a recording is running or paused, since a bookmark needs a file to attach itself to. Each tap stores the current moment, bumps the small count under the icon, and confirms the timestamp with a toast. The same button sits in the fullscreen preview dock, so a moment can be marked without leaving fullscreen, and dual-camera recordings can be marked too.

**During playback** — the video player draws every mark on the time slider and shows a bookmarks button in the control bar. The sheet behind it lists each mark by timestamp: tap to jump straight there, or delete one / clear them all.

## How it works

- New `com.fadcam.bookmarks` package: an immutable `Bookmark` model and a `BookmarkRepository` that keeps one JSON array per recording in its own prefs file.
- Bookmarks are keyed by the media **display name**, not its URI — SAF document URIs change on rename and on the trash/restore round-trip, the name does not. Renaming a recording re-keys its marks (to the name the file actually ended up with, since a collision can append a suffix); deleting it permanently (or emptying the trash) drops them.
- Positions are stored **relative to the active segment**, not the session, so split recordings (`_partN`) map onto the right file: `RecordingService` anchors the segment on its own timeline at every rollover and subtracts that anchor when a bookmark comes in.
- The recording services own the write path — each is the single source of truth for its own timeline and output URI — and answer with a local broadcast carrying the position and the running total. `RecordingService` handles single-camera recordings; `DualCameraRecordingService` handles dual ones and marks against its own effective timeline.
- Markers are drawn by `BookmarkMarkersView`, aligned to the Material slider through `getTrackSidePadding()` / `getTrackWidth()`. The overlay is non-clickable, so scrubbing still reaches the slider underneath.

## Files

| Area | Change |
|---|---|
| `com/fadcam/bookmarks/` | `Bookmark`, `BookmarkRepository`, `ui/BookmarkMarkersView`, `ui/BookmarksBottomSheet` |
| `Constants` | bookmark intent action, broadcast + extras, quick-action default order |
| `RecordingService` | segment anchor, `INTENT_ACTION_ADD_BOOKMARK`, result broadcast |
| `DualCameraRecordingService` | `INTENT_ACTION_ADD_BOOKMARK` against the dual timeline, result broadcast |
| `HomeFragment` + `fragment_home.xml` (portrait & landscape) | the quick action, its slot registration and visibility rules |
| `FullscreenPreviewActivity` + `activity_fullscreen_preview.xml` | the same mark action inside the fullscreen dock |
| `VideoPlayerActivity` + `exo_styled_player_control_view.xml` | timeline markers and the bookmarks button |
| `RecordsAdapter`, `TrashManager` | keep bookmarks in step with rename and delete |

## Testing

`./gradlew assembleDefaultDebug` passes. I could not run the device playbook from `AGENTS.md` — no device was attached to the machine I built on — so the on-device pass (record → mark → play back → jump) is worth a look before merging, single-camera and dual.

## Not covered

- Marks carry a timestamp only — no label or note on a mark.
- Nothing surfaces them outside the player: no marker count in the records list, and no way to export them alongside the video.
